### PR TITLE
Migrate imagej-maven-plugin

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
-Copyright (c) 2014 - 2016, Board of Regents of the University of
-Wisconsin-Madison.
+Copyright (c) 2014 - 2018, Board of Regents of the University of
+Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -14,10 +14,20 @@ $ mvn scijava:help
 [INFO] SciJava plugin for Maven 0.5.0
   A plugin for managing SciJava-based projects.
 
-This plugin has 5 goals:
+This plugin has 7 goals:
 
 scijava:bump
   Bumps dependency and parent versions in SciJava projects.
+
+scijava:copy-jars
+  Copies .jar artifacts and their dependencies into a SciJava application
+  directory structure. ImageJ 1.x plugins (identified by containing a
+  plugins.config file) get copied to the plugins/ subdirectory and all other
+  .jar files to jars/. However, you can override this decision by setting the
+  scijava.app.subdirectory property to a specific subdirectory. It expects the
+  location of the SciJava application directory to be specified in the
+  scijava.app.directory property (which can be set on the Maven command-line).
+  If said property is not set, the copy-jars goal is skipped.
 
 scijava:eclipse-helper
   Runs the annotation processor of the scijava-common artifact even inside
@@ -27,6 +37,16 @@ scijava:help
   Display help information on scijava-maven-plugin.
   Call mvn scijava:help -Ddetail=true -Dgoal=<goal-name> to display parameter
   details.
+
+scijava:install-artifact
+  Downloads .jar artifacts and their dependencies into a SciJava application
+  directory structure. ImageJ 1.x plugins (identified by containing a
+  plugins.config file) get copied to the plugins/ subdirectory and all other
+  .jar files to jars/. However, you can override this decision by setting the
+  scijava.app.subdirectory property to a specific subdirectory. It expects the
+  location of the SciJava application directory to be specified in the
+  scijava.app.directory property (which can be set on the Maven command-line).
+  If said property is not set, the install-artifact goal is skipped.
 
 scijava:set-rootdir
   Sets the project.rootdir property to the top-level directory of the current
@@ -47,8 +67,9 @@ scijava:verify-no-snapshots
 Usage
 -----
 
-It is recommended to enable the set-rootdir goal by making the
-[SciJava POM](http://github.com/scijava/pom-scijava) the parent project:
+It is recommended to enable the _set-rootdir_ as well as the _copy-jars_
+goal by making the [SciJava POM](http://github.com/scijava/pom-scijava)
+the parent project:
 
 ```xml
 <project ...>
@@ -76,6 +97,13 @@ Alternatively, you can include the plugin explicitly in the life cycle:
         <phase>validate</phase>
         <goals>
           <goal>set-rootdir</goal>
+        </goals>
+      </execution>
+      <execution>
+        <id>copy-jars</id>
+        <phase>install</phase>
+        <goals>
+          <goal>copy-jars</goal>
         </goals>
       </execution>
     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.1.1</version>
+		<version>23.2.0</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>9.0.0</version>
+		<version>17.1.1</version>
 		<relativePath />
 	</parent>
 
@@ -15,7 +15,12 @@
 
 	<name>SciJava plugin for Maven</name>
 	<description>A plugin for managing SciJava-based projects.</description>
+	<url>https://github.com/scijava/scijava-maven-plugin</url>
 	<inceptionYear>2014</inceptionYear>
+	<organization>
+		<name>SciJava</name>
+		<url>http://www.scijava.org/</url>
+	</organization>
 	<licenses>
 		<license>
 			<name>Simplified BSD License</name>
@@ -30,6 +35,18 @@
 			<url>http://imagej.net/User:Rueden</url>
 			<roles>
 				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+		<developer>
+			<id>stelfrich</id>
+			<name>Stefan Helfrich</name>
+			<url>http://imagej.net/User:Stelfrich</url>
+			<roles>
 				<role>developer</role>
 				<role>debugger</role>
 				<role>reviewer</role>
@@ -52,18 +69,43 @@
 		</contributor>
 	</contributors>
 
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
+
 	<scm>
 		<connection>scm:git:git://github.com/scijava/scijava-maven-plugin</connection>
 		<developerConnection>scm:git:git@github.com:scijava/scijava-maven-plugin</developerConnection>
 		<tag>HEAD</tag>
 		<url>https://github.com/scijava/scijava-maven-plugin</url>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/scijava/scijava-maven-plugin/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Travis CI</system>
+		<url>https://travis-ci.org/scijava/scijava-maven-plugin</url>
+	</ciManagement>
 
 	<properties>
 		<enforcer.version>1.3.1</enforcer.version>
+		<license.licenseName>bsd_2</license.licenseName>
+		<license.copyrightOwners>Board of Regents of the University of
+Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+Institute of Molecular Cell Biology and Genetics, University of
+Konstanz, and KNIME GmbH.</license.copyrightOwners>
+		<license.projectName>SciJava Common shared library for SciJava software.</license.projectName>
+		<maven.compiler.source>1.8</maven.compiler.source>
+    	<maven.compiler.target>1.6</maven.compiler.target>
 		<maven.version>3.0</maven.version>
 		<maven2.version>2.2.1</maven2.version>
 		<maven-tree.version>2.2</maven-tree.version>
+		<package-name>org.scijava.maven</package-name>
+		<scijava-common.version>2.66.0</scijava-common.version>
 	</properties>
 
 	<dependencies>
@@ -87,48 +129,6 @@
 				<exclusion>
 					<groupId>org.codehaus.plexus</groupId>
 					<artifactId>plexus-container-default</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-artifact</artifactId>
-			<version>${maven2.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.codehaus.plexus</groupId>
-					<artifactId>plexus-utils</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>${maven2.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.codehaus.plexus</groupId>
-					<artifactId>plexus-interpolation</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.plexus</groupId>
-					<artifactId>plexus-utils</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.maven</groupId>
-					<artifactId>maven-artifact-manager</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.maven</groupId>
-					<artifactId>maven-model</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.maven</groupId>
-					<artifactId>maven-settings</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>classworlds</groupId>
-					<artifactId>classworlds</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -166,12 +166,56 @@
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.3</version>
+			<version>3.5</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-artifact</artifactId>
+			<version>${maven.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+			<version>${maven.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-model</artifactId>
+			<version>${maven.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-artifact-transfer</artifactId>
+			<version>0.9.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-common-artifact-filters</artifactId>
+			<version>3.0.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-interpolation</artifactId>
+			<version>1.24</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-common</artifactId>
+			<version>${scijava-common.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -205,6 +249,18 @@
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>1.0</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.codehaus.mojo</groupId>
+							<artifactId>extra-enforcer-rules</artifactId>
+							<version>1.0-beta-9</version>
+						</dependency>
+					</dependencies>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -212,26 +268,19 @@
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<configuration>
 					<rules>
-						<banClasses>
+						<banDuplicateClasses>
 							<!--
 							NB: maven-artifact and maven-project are 2.0 artifacts
 							that clash with maven-core 3.0.
 							-->
-							<dependencies>
-								<dependency>
-									<artifactId>maven-artifact</artifactId>
-									<ignoreClasses>
-										<ignoreClass>org/apache/maven/artifact/*</ignoreClass>
-									</ignoreClasses>
-								</dependency>
-								<dependency>
-									<artifactId>maven-project</artifactId>
-									<ignoreClasses>
-										<ignoreClass>org/apache/maven/project/*</ignoreClass>
-									</ignoreClasses>
-								</dependency>
-							</dependencies>
-						</banClasses>
+							<ignoreClasses>
+								<ignoreClass>org/apache/maven/artifact/*</ignoreClass>
+
+								<ignoreClass>org/apache/maven/project/*</ignoreClass>
+							</ignoreClasses>
+							<findAllDuplicates>true</findAllDuplicates>
+							<ignoreWhenIdentical>true</ignoreWhenIdentical>
+						</banDuplicateClasses>
 					</rules>
 				</configuration>
 			</plugin>
@@ -253,13 +302,40 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>license-maven-plugin</artifactId>
+				<artifactId>maven-invoker-plugin</artifactId>
+				<version>1.8</version>
 				<configuration>
-					<licenseName>bsd_2</licenseName>
-					<organizationName>Board of Regents of the University of
-Wisconsin-Madison.</organizationName>
+					<!-- <debug>true</debug> -->
+					<showErrors>true</showErrors>
+					<streamLogs>true</streamLogs>
+					<properties>
+						<scijava-maven.version>${project.version}</scijava-maven.version>
+					</properties>
+					<projectsDirectory>src/it</projectsDirectory>
+					<cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+					<pomIncludes>
+						<pomInclude>*/pom.xml</pomInclude>
+					</pomIncludes>
+					<settingsFile>src/it/settings.xml</settingsFile>
+					<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+					<preBuildHookScript>setup.bsh</preBuildHookScript>
+					<postBuildHookScript>verify.bsh</postBuildHookScript>
+					<goals>
+						<goal>install</goal>
+					</goals>
 				</configuration>
+				<executions>
+					<execution>
+						<id>integration-test</id>
+						<goals>
+							<goal>install</goal>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,10 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Board of Regents of the University of
 Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
-Institute of Molecular Cell Biology and Genetics, University of
-Konstanz, and KNIME GmbH.</license.copyrightOwners>
-		<license.projectName>SciJava Common shared library for SciJava software.</license.projectName>
+Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.</license.copyrightOwners>
+		<license.projectName>A plugin for managing SciJava-based projects.</license.projectName>
 		<maven.compiler.source>1.8</maven.compiler.source>
-    	<maven.compiler.target>1.6</maven.compiler.target>
+		<maven.compiler.target>1.6</maven.compiler.target>
 		<maven.version>3.0</maven.version>
 		<maven2.version>2.2.1</maven2.version>
 		<maven-tree.version>2.2</maven-tree.version>

--- a/src/it/copy-jars/pom.xml
+++ b/src/it/copy-jars/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/copy-jars/pom.xml
+++ b/src/it/copy-jars/pom.xml
@@ -53,7 +53,7 @@
 	</dependencies>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -78,7 +78,7 @@
 							<goal>install-artifact</goal>
 						</goals>
 						<configuration>
-							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<appDirectory>${project.basedir}/target/Other.app/</appDirectory>
 							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
 						</configuration>
 					</execution>

--- a/src/it/copy-jars/pom.xml
+++ b/src/it/copy-jars/pom.xml
@@ -1,0 +1,89 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.48s</version>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/copy-jars/setup.bsh
+++ b/src/it/copy-jars/setup.bsh
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();
+touchFile(new File(plugins, "Example_PlugIn-0.9.0-obsolete.jar"));

--- a/src/it/copy-jars/setup.bsh
+++ b/src/it/copy-jars/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/copy-jars/src/main/java/Example_PlugIn.java
+++ b/src/it/copy-jars/src/main/java/Example_PlugIn.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import ij.IJ;
+import ij.plugin.PlugIn;
+
+/**
+ * A very simple plugin for testing purposes.
+ *
+ * @author Johannes Schindelin
+ */
+public class Example_PlugIn implements PlugIn {
+	public void run(final String arg) {
+		IJ.log("Hello, World!");
+	}
+}

--- a/src/it/copy-jars/src/main/java/Example_PlugIn.java
+++ b/src/it/copy-jars/src/main/java/Example_PlugIn.java
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/copy-jars/src/main/resources/plugins.config
+++ b/src/it/copy-jars/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+Example, "Plug In", Example_PlugIn

--- a/src/it/copy-jars/src/main/resources/plugins.config
+++ b/src/it/copy-jars/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/copy-jars/verify.bsh
+++ b/src/it/copy-jars/verify.bsh
@@ -1,0 +1,41 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should exist: " + plugin, plugin.exists());
+
+// install-artifact must not copy test scope dependencies
+junit = new File(ijDir, "../Other.app/jars/junit-4.8.1.jar");
+assertTrue("Should not exist: " + junit, !junit.exists());
+
+// but it must copy the ij dependency
+ij = new File(ijDir, "../Other.app/jars/ij-1.48s.jar");
+assertTrue("ImageJ 1.x was not copied: " + ij, ij.exists());

--- a/src/it/copy-jars/verify.bsh
+++ b/src/it/copy-jars/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/copy-to-subdirectory/pom.xml
+++ b/src/it/copy-to-subdirectory/pom.xml
@@ -47,8 +47,8 @@
 	</dependencies>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
-		<imagej.app.subdirectory>plugins/Test/Directory/</imagej.app.subdirectory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
+		<scijava.app.subdirectory>plugins/Test/Directory/</scijava.app.subdirectory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -73,8 +73,8 @@
 							<goal>install-artifact</goal>
 						</goals>
 						<configuration>
-							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
-							<imagejSubdirectory>jars/Subdirectory/</imagejSubdirectory>
+							<appDirectory>${project.basedir}/target/Other.app/</appDirectory>
+							<appSubdirectory>jars/Subdirectory/</appSubdirectory>
 							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
 						</configuration>
 					</execution>

--- a/src/it/copy-to-subdirectory/pom.xml
+++ b/src/it/copy-to-subdirectory/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/copy-to-subdirectory/pom.xml
+++ b/src/it/copy-to-subdirectory/pom.xml
@@ -1,0 +1,85 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.48s</version>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<imagej.app.subdirectory>plugins/Test/Directory/</imagej.app.subdirectory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<imagejSubdirectory>jars/Subdirectory/</imagejSubdirectory>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/copy-to-subdirectory/setup.bsh
+++ b/src/it/copy-to-subdirectory/setup.bsh
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();

--- a/src/it/copy-to-subdirectory/setup.bsh
+++ b/src/it/copy-to-subdirectory/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/copy-to-subdirectory/src/main/resources/plugins.config
+++ b/src/it/copy-to-subdirectory/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/copy-to-subdirectory/src/main/resources/plugins.config
+++ b/src/it/copy-to-subdirectory/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/copy-to-subdirectory/verify.bsh
+++ b/src/it/copy-to-subdirectory/verify.bsh
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+subdirectory = new File(plugins, "Test/Directory/");
+assertTrue("Should exist: " + subdirectory, subdirectory.exists());
+jar = new File(subdirectory, "Example_PlugIn-1.0.0-SNAPSHOT.jar");
+assertTrue("Should exist: " + jar, jar.exists());
+
+subdirectoryPlugin = new File(ijDir, "../Other.app/jars/Subdirectory/Example_PlugIn-1.0.0-SNAPSHOT.jar");
+assertTrue("Should exist: " + subdirectoryPlugin, subdirectoryPlugin.exists());

--- a/src/it/copy-to-subdirectory/verify.bsh
+++ b/src/it/copy-to-subdirectory/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-configuration/pom.xml
+++ b/src/it/delete-other-versions-configuration/pom.xml
@@ -39,7 +39,7 @@
 	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/src/it/delete-other-versions-configuration/pom.xml
+++ b/src/it/delete-other-versions-configuration/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-configuration/pom.xml
+++ b/src/it/delete-other-versions-configuration/pom.xml
@@ -1,0 +1,67 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+						<configuration>
+							<deleteOtherVersions>false</deleteOtherVersions>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/delete-other-versions-configuration/setup.bsh
+++ b/src/it/delete-other-versions-configuration/setup.bsh
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();
+touchFile(new File(plugins, "Example_PlugIn-1.1.0.jar"));

--- a/src/it/delete-other-versions-configuration/setup.bsh
+++ b/src/it/delete-other-versions-configuration/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-configuration/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-configuration/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/delete-other-versions-configuration/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-configuration/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-configuration/verify.bsh
+++ b/src/it/delete-other-versions-configuration/verify.bsh
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should not exist: " + plugin, !plugin.exists());
+otherVersion = new File(plugins, "Example_PlugIn-1.1.0.jar");
+assertTrue("Should exist: " + otherVersion, otherVersion.exists());

--- a/src/it/delete-other-versions-configuration/verify.bsh
+++ b/src/it/delete-other-versions-configuration/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-in-subdirectory/pom.xml
+++ b/src/it/delete-other-versions-in-subdirectory/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-in-subdirectory/pom.xml
+++ b/src/it/delete-other-versions-in-subdirectory/pom.xml
@@ -1,0 +1,68 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<imagej.app.subdirectory>plugins/Test2/</imagej.app.subdirectory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<configuration>
+					<deleteOtherVersionsPolicy>always</deleteOtherVersionsPolicy>
+				</configuration>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/delete-other-versions-in-subdirectory/pom.xml
+++ b/src/it/delete-other-versions-in-subdirectory/pom.xml
@@ -39,8 +39,8 @@
 	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
-		<imagej.app.subdirectory>plugins/Test2/</imagej.app.subdirectory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
+		<scijava.app.subdirectory>plugins/Test2/</scijava.app.subdirectory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/src/it/delete-other-versions-in-subdirectory/setup.bsh
+++ b/src/it/delete-other-versions-in-subdirectory/setup.bsh
@@ -1,0 +1,40 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();
+subdir = new File(plugins, "Test");
+subdir.mkdirs();
+
+subdir2 = new File(plugins, "Test2");
+subdir2.mkdirs();
+
+touchFile(new File(subdir, "Example_PlugIn-0.9.0-obsolete.jar"));

--- a/src/it/delete-other-versions-in-subdirectory/setup.bsh
+++ b/src/it/delete-other-versions-in-subdirectory/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-in-subdirectory/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-in-subdirectory/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/delete-other-versions-in-subdirectory/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-in-subdirectory/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-in-subdirectory/verify.bsh
+++ b/src/it/delete-other-versions-in-subdirectory/verify.bsh
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+testSubdir = new File(plugins, "Test/");
+obsolete = new File(testSubdir, "Example_PlugIn-0.9.0-obsolete.jar");
+assertTrue("Should not exist: " + obsolete, !obsolete.exists());
+
+testSubdir2 = new File(plugins, "Test2");
+jar = new File(testSubdir2, "Example_PlugIn-1.0.0-SNAPSHOT.jar");
+assertTrue("Should exist: " + jar, jar.exists());

--- a/src/it/delete-other-versions-in-subdirectory/verify.bsh
+++ b/src/it/delete-other-versions-in-subdirectory/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-policy/pom.xml
+++ b/src/it/delete-other-versions-policy/pom.xml
@@ -1,0 +1,77 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<imagej.deleteOtherVersions>always</imagej.deleteOtherVersions>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+							<deleteOtherVersionsPolicy>older</deleteOtherVersionsPolicy>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/delete-other-versions-policy/pom.xml
+++ b/src/it/delete-other-versions-policy/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-policy/pom.xml
+++ b/src/it/delete-other-versions-policy/pom.xml
@@ -39,9 +39,9 @@
 	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<imagej.deleteOtherVersions>always</imagej.deleteOtherVersions>
+		<scijava.deleteOtherVersions>always</scijava.deleteOtherVersions>
 	</properties>
 
 	<build>
@@ -65,7 +65,7 @@
 							<goal>install-artifact</goal>
 						</goals>
 						<configuration>
-							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<appDirectory>${project.basedir}/target/Other.app/</appDirectory>
 							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
 							<deleteOtherVersionsPolicy>older</deleteOtherVersionsPolicy>
 						</configuration>

--- a/src/it/delete-other-versions-policy/setup.bsh
+++ b/src/it/delete-other-versions-policy/setup.bsh
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+// copy-jars
+if (!plugins.exists()) plugins.mkdirs();
+touchFile(new File(plugins, "Example_PlugIn-1.1.0.jar"));
+
+// install-artifact
+other = new File(basedir, "target/Other.app/");
+if (!other.exists()) other.mkdirs();
+
+otherPlugins = new File(other, "plugins/");
+if (!otherPlugins.exists()) otherPlugins.mkdirs();
+
+touchFile(new File(otherPlugins, "Example_PlugIn-2.1.0.jar"));

--- a/src/it/delete-other-versions-policy/setup.bsh
+++ b/src/it/delete-other-versions-policy/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-policy/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-policy/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/delete-other-versions-policy/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-policy/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-policy/verify.bsh
+++ b/src/it/delete-other-versions-policy/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-policy/verify.bsh
+++ b/src/it/delete-other-versions-policy/verify.bsh
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+// copy-jars
+assertTrue("Should exist: " + plugin, plugin.exists());
+newer = new File(plugins, "Example_PlugIn-1.1.0.jar");
+assertTrue("Should not exist: " + newer, !newer.exists());
+
+// install-artifact
+other = new File(basedir, "target/Other.app/");
+assertTrue("Should exist: "+ other, other.exists());
+
+otherPlugins = new File(other, "plugins/");
+assertTrue("Should exist: "+ otherPlugins, otherPlugins.exists());
+
+newer = new File(otherPlugins, "Example_PlugIn-2.1.0.jar");
+assertTrue("Should exist: " + newer, newer.exists());
+toInstall = new File(otherPlugins, "Example_PlugIn-1.0.0-SNAPSHOT.jar");
+assertTrue("Should not exist: " + newer, !toInstall.exists());
+
+buildLog = readFile(new File(basedir, "build.log"));
+assertTrue("Found other version that is incompatible':\n" + buildLog,
+	buildLog.contains("Found other version that is incompatible"));

--- a/src/it/delete-other-versions-property-false/pom.xml
+++ b/src/it/delete-other-versions-property-false/pom.xml
@@ -39,7 +39,7 @@
 	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
 
 	<properties>
-		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<delete.other.versions>false</delete.other.versions>
 	</properties>

--- a/src/it/delete-other-versions-property-false/pom.xml
+++ b/src/it/delete-other-versions-property-false/pom.xml
@@ -39,7 +39,7 @@
 	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<delete.other.versions>false</delete.other.versions>
 	</properties>

--- a/src/it/delete-other-versions-property-false/pom.xml
+++ b/src/it/delete-other-versions-property-false/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-property-false/pom.xml
+++ b/src/it/delete-other-versions-property-false/pom.xml
@@ -1,0 +1,65 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<delete.other.versions>false</delete.other.versions>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/delete-other-versions-property-false/setup.bsh
+++ b/src/it/delete-other-versions-property-false/setup.bsh
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();
+touchFile(new File(plugins, "Example_PlugIn-1.1.0.jar"));

--- a/src/it/delete-other-versions-property-false/setup.bsh
+++ b/src/it/delete-other-versions-property-false/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-property-false/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-property-false/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/delete-other-versions-property-false/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-property-false/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-property-false/verify.bsh
+++ b/src/it/delete-other-versions-property-false/verify.bsh
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should exist: " + plugin, plugin.exists());
+otherVersion = new File(plugins, "Example_PlugIn-1.1.0.jar");
+assertTrue("Should exist: " + otherVersion, otherVersion.exists());

--- a/src/it/delete-other-versions-property-false/verify.bsh
+++ b/src/it/delete-other-versions-property-false/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-property-true/pom.xml
+++ b/src/it/delete-other-versions-property-true/pom.xml
@@ -39,7 +39,7 @@
 	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<delete.other.versions>true</delete.other.versions>
 	</properties>

--- a/src/it/delete-other-versions-property-true/pom.xml
+++ b/src/it/delete-other-versions-property-true/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-property-true/pom.xml
+++ b/src/it/delete-other-versions-property-true/pom.xml
@@ -39,7 +39,7 @@
 	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
 
 	<properties>
-		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<delete.other.versions>true</delete.other.versions>
 	</properties>

--- a/src/it/delete-other-versions-property-true/pom.xml
+++ b/src/it/delete-other-versions-property-true/pom.xml
@@ -1,0 +1,65 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<delete.other.versions>true</delete.other.versions>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/delete-other-versions-property-true/setup.bsh
+++ b/src/it/delete-other-versions-property-true/setup.bsh
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();
+touchFile(new File(plugins, "Example_PlugIn-1.1.0.jar"));

--- a/src/it/delete-other-versions-property-true/setup.bsh
+++ b/src/it/delete-other-versions-property-true/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-property-true/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-property-true/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/delete-other-versions-property-true/src/main/resources/plugins.config
+++ b/src/it/delete-other-versions-property-true/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/delete-other-versions-property-true/verify.bsh
+++ b/src/it/delete-other-versions-property-true/verify.bsh
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should not exist: " + plugin, !plugin.exists());
+otherVersion = new File(plugins, "Example_PlugIn-1.1.0.jar");
+assertTrue("Should exist: " + otherVersion, otherVersion.exists());

--- a/src/it/delete-other-versions-property-true/verify.bsh
+++ b/src/it/delete-other-versions-property-true/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/do-not-delete-natives/pom.xml
+++ b/src/it/do-not-delete-natives/pom.xml
@@ -39,7 +39,7 @@
 	<name>An example ImageJ 1.x plugin to test if LWJGL natives-* files are kept</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/src/it/do-not-delete-natives/pom.xml
+++ b/src/it/do-not-delete-natives/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/do-not-delete-natives/pom.xml
+++ b/src/it/do-not-delete-natives/pom.xml
@@ -1,0 +1,67 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test if LWJGL natives-* files are kept</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<configuration>
+					<deleteOtherVersionsPolicy>always</deleteOtherVersionsPolicy>
+				</configuration>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/do-not-delete-natives/setup.bsh
+++ b/src/it/do-not-delete-natives/setup.bsh
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();
+touchFile(new File(plugins, "Example_PlugIn-0.9.0-natives-linux.jar"));

--- a/src/it/do-not-delete-natives/setup.bsh
+++ b/src/it/do-not-delete-natives/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/do-not-delete-natives/src/main/resources/plugins.config
+++ b/src/it/do-not-delete-natives/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+# Intentionally left blank

--- a/src/it/do-not-delete-natives/src/main/resources/plugins.config
+++ b/src/it/do-not-delete-natives/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/do-not-delete-natives/verify.bsh
+++ b/src/it/do-not-delete-natives/verify.bsh
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should exist: " + plugin, plugin.exists());
+natives = new File(plugins, "Example_PlugIn-0.9.0-natives-linux.jar");
+assertTrue("Should exist: " + natives, natives.exists());

--- a/src/it/do-not-delete-natives/verify.bsh
+++ b/src/it/do-not-delete-natives/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/exclusions/dependency/pom.xml
+++ b/src/it/exclusions/dependency/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/exclusions/dependency/pom.xml
+++ b/src/it/exclusions/dependency/pom.xml
@@ -1,0 +1,48 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>dependency</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example artifact with a dependency to be excluded via &lt;exclusions&gt;</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>excluded</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/src/it/exclusions/excluded/pom.xml
+++ b/src/it/exclusions/excluded/pom.xml
@@ -1,0 +1,41 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>excluded</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example artifact to exclude via &lt;exclusions&gt;</name>
+</project>

--- a/src/it/exclusions/excluded/pom.xml
+++ b/src/it/exclusions/excluded/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -1,0 +1,50 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>exclusions</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>Top-level project for testing exclusions</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<modules>
+		<module>excluded</module>
+		<module>dependency</module>
+		<module>to-copy</module>
+	</modules>
+</project>

--- a/src/it/exclusions/setup.bsh
+++ b/src/it/exclusions/setup.bsh
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();

--- a/src/it/exclusions/setup.bsh
+++ b/src/it/exclusions/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/exclusions/to-copy/pom.xml
+++ b/src/it/exclusions/to-copy/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/exclusions/to-copy/pom.xml
+++ b/src/it/exclusions/to-copy/pom.xml
@@ -40,7 +40,7 @@
 	<name>An example artifact to test support for &lt;exclusions&gt;</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/../target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/../target/ImageJ.app/</scijava.app.directory>
 	</properties>
 
 	<dependencies>

--- a/src/it/exclusions/to-copy/pom.xml
+++ b/src/it/exclusions/to-copy/pom.xml
@@ -1,0 +1,78 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>to-copy</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example artifact to test support for &lt;exclusions&gt;</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/../target/ImageJ.app/</imagej.app.directory>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>dependency</artifactId>
+			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>excluded</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/exclusions/verify.bsh
+++ b/src/it/exclusions/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/exclusions/verify.bsh
+++ b/src/it/exclusions/verify.bsh
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+jars = new File(ijDir, "jars");
+assertTrue("Does not have to-copy.jar", new File(jars, "to-copy-1.0.0-SNAPSHOT.jar").exists());
+assertTrue("Does not have dependency.jar", new File(jars, "dependency-1.0.0-SNAPSHOT.jar").exists());
+assertTrue("Has excluded.jar", !new File(jars, "excluded-1.0.0-SNAPSHOT.jar").exists());

--- a/src/it/handle-missing-version-numbers/pom.xml
+++ b/src/it/handle-missing-version-numbers/pom.xml
@@ -40,8 +40,8 @@
 	<name>An example artifact to test support for missing version numbers</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
-		<imagej.deleteOtherVersions>older</imagej.deleteOtherVersions>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
+		<scijava.deleteOtherVersions>older</scijava.deleteOtherVersions>
 	</properties>
 
 	<build>

--- a/src/it/handle-missing-version-numbers/pom.xml
+++ b/src/it/handle-missing-version-numbers/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/handle-missing-version-numbers/pom.xml
+++ b/src/it/handle-missing-version-numbers/pom.xml
@@ -1,0 +1,65 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>missing-version-number</artifactId>
+	<version>1.0.0</version>
+	<packaging>jar</packaging>
+	<name>An example artifact to test support for missing version numbers</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<imagej.deleteOtherVersions>older</imagej.deleteOtherVersions>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/handle-missing-version-numbers/setup.bsh
+++ b/src/it/handle-missing-version-numbers/setup.bsh
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+jars = new File(ijDir, "jars");
+if (!jars.exists()) jars.mkdirs();
+touchFile(new File(jars, "missing-version-number.jar"));

--- a/src/it/handle-missing-version-numbers/setup.bsh
+++ b/src/it/handle-missing-version-numbers/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/handle-missing-version-numbers/verify.bsh
+++ b/src/it/handle-missing-version-numbers/verify.bsh
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+jars = new File(ijDir, "jars");
+assertTrue("Has missing-version-number-1.0.0.jar",
+	!new File(jars, "missing-version-number-1.0.0.jar").exists());
+
+buildLog = readFile(new File(basedir, "build.log"));
+assertTrue("Should contain 'Impenetrable version suffix':\n" + buildLog,
+	buildLog.contains("Impenetrable version suffix"));

--- a/src/it/handle-missing-version-numbers/verify.bsh
+++ b/src/it/handle-missing-version-numbers/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/ignore-dependencies/pom.xml
+++ b/src/it/ignore-dependencies/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/ignore-dependencies/pom.xml
+++ b/src/it/ignore-dependencies/pom.xml
@@ -1,0 +1,85 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example artifact to test ignoring dependencies</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.ignoreDependencies>true</scijava.ignoreDependencies>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.48s</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+							<ignoreDependencies>true</ignoreDependencies>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/ignore-dependencies/pom.xml
+++ b/src/it/ignore-dependencies/pom.xml
@@ -40,7 +40,7 @@
 	<name>An example artifact to test ignoring dependencies</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<scijava.ignoreDependencies>true</scijava.ignoreDependencies>
 	</properties>
 
@@ -73,7 +73,7 @@
 							<goal>install-artifact</goal>
 						</goals>
 						<configuration>
-							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<appDirectory>${project.basedir}/target/Other.app/</appDirectory>
 							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
 							<ignoreDependencies>true</ignoreDependencies>
 						</configuration>

--- a/src/it/ignore-dependencies/setup.bsh
+++ b/src/it/ignore-dependencies/setup.bsh
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();

--- a/src/it/ignore-dependencies/setup.bsh
+++ b/src/it/ignore-dependencies/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/ignore-dependencies/src/main/resources/plugins.config
+++ b/src/it/ignore-dependencies/src/main/resources/plugins.config
@@ -1,0 +1,31 @@
+###
+# #%L
+# ImageJ software for multidimensional image processing and analysis.
+# %%
+# Copyright (C) 2012 - 2016 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+# Institute of Molecular Cell Biology and Genetics.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+Example, "Plug In", Example_PlugIn

--- a/src/it/ignore-dependencies/src/main/resources/plugins.config
+++ b/src/it/ignore-dependencies/src/main/resources/plugins.config
@@ -1,10 +1,10 @@
 ###
 # #%L
-# ImageJ software for multidimensional image processing and analysis.
+# A plugin for managing SciJava-based projects.
 # %%
-# Copyright (C) 2012 - 2016 Board of Regents of the University of
-# Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-# Institute of Molecular Cell Biology and Genetics.
+# Copyright (C) 2014 - 2018 Board of Regents of the University of
+# Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+# Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
 # %%
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/it/ignore-dependencies/verify.bsh
+++ b/src/it/ignore-dependencies/verify.bsh
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should exist: " + plugin, plugin.exists());
+
+ij = new File(ijDir, "jars/ij-1.48s.jar");
+assertTrue("Should not exist: " + ij, !ij.exists());
+
+otherIJ = new File(ijDir, "../Other.app/jars/ij-1.48s.jar");
+assertTrue("Should not exist: " + otherIJ, !otherIJ.exists());

--- a/src/it/ignore-dependencies/verify.bsh
+++ b/src/it/ignore-dependencies/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/imagej-property-compatibility/pom.xml
+++ b/src/it/imagej-property-compatibility/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/imagej-property-compatibility/pom.xml
+++ b/src/it/imagej-property-compatibility/pom.xml
@@ -1,0 +1,79 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>example-artifact</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example artifact to test backwards compatibility with imagej-based properties</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<imagej.app.subdirectory>plugins</imagej.app.subdirectory>
+		<imagej.deleteOtherVersions>older</imagej.deleteOtherVersions>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<imagejDirectory>${project.basedir}/target/Other.app/</imagejDirectory>
+							<imagejSubdirectory>plugins</imagejSubdirectory>
+							<imagejDeleteOtherVersionsPolicy>older</imagejDeleteOtherVersionsPolicy>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/imagej-property-compatibility/setup.bsh
+++ b/src/it/imagej-property-compatibility/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/imagej-property-compatibility/setup.bsh
+++ b/src/it/imagej-property-compatibility/setup.bsh
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+// copy-jars
+if (!plugins.exists()) plugins.mkdirs();
+touchFile(new File(plugins, "example-artifact-1.1.0.jar"));
+
+// install-artifact
+other = new File(basedir, "target/Other.app/");
+if (!other.exists()) other.mkdirs();
+
+otherPlugins = new File(other, "plugins/");
+if (!otherPlugins.exists()) otherPlugins.mkdirs();
+
+touchFile(new File(otherPlugins, "example-artifact-2.1.0.jar"));

--- a/src/it/imagej-property-compatibility/verify.bsh
+++ b/src/it/imagej-property-compatibility/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/imagej-property-compatibility/verify.bsh
+++ b/src/it/imagej-property-compatibility/verify.bsh
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+// copy-jars
+newer = new File(plugins, "example-artifact-1.1.0.jar");
+assertTrue("Should exist: " + newer, newer.exists());
+
+// install-artifact
+other = new File(basedir, "target/Other.app/");
+assertTrue("Should exist: "+ other, other.exists());
+
+otherPlugins = new File(other, "plugins/");
+assertTrue("Should exist: "+ otherPlugins, otherPlugins.exists());
+
+newer = new File(otherPlugins, "example-artifact-2.1.0.jar");
+assertTrue("Should exist: " + newer, newer.exists());
+toInstall = new File(otherPlugins, "example-artifact-1.0.0-SNAPSHOT.jar");
+assertTrue("Should not exist: " + newer, !toInstall.exists());
+
+buildLog = readFile(new File(basedir, "build.log"));
+assertTrue("Found other version that is incompatible':\n" + buildLog,
+	buildLog.contains("Found other version that is incompatible"));
+
+assertTrue("Log should contain warning about legacy property 'imagej.app.directory'",
+	buildLog.contains("Property 'imagej.app.directory' is deprecated. Use 'scijava.app.directory' instead"));
+assertTrue("Log should contain warning about legacy property 'imagej.app.subdirectory'",
+	buildLog.contains("Property 'imagej.app.subdirectory' is deprecated. Use 'scijava.app.subdirectory' instead"));
+assertTrue("Log should contain warning about legacy property 'imagej.deleteOtherVersions'",
+	buildLog.contains("Property 'imagej.deleteOtherVersions' is deprecated. Use 'scijava.deleteOtherVersions' instead"));

--- a/src/it/install-from-local-repo/only-local/pom.xml
+++ b/src/it/install-from-local-repo/only-local/pom.xml
@@ -1,0 +1,41 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>only-local</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example artifact that is only available in the local repository</name>
+</project>

--- a/src/it/install-from-local-repo/only-local/pom.xml
+++ b/src/it/install-from-local-repo/only-local/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/install-from-local-repo/pom.xml
+++ b/src/it/install-from-local-repo/pom.xml
@@ -1,0 +1,49 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>exclusions</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>Top-level project for testing installing from local repository</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<modules>
+		<module>only-local</module>
+		<module>to-copy</module>
+	</modules>
+</project>

--- a/src/it/install-from-local-repo/pom.xml
+++ b/src/it/install-from-local-repo/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/install-from-local-repo/setup.bsh
+++ b/src/it/install-from-local-repo/setup.bsh
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();

--- a/src/it/install-from-local-repo/setup.bsh
+++ b/src/it/install-from-local-repo/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/install-from-local-repo/to-copy/pom.xml
+++ b/src/it/install-from-local-repo/to-copy/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/install-from-local-repo/to-copy/pom.xml
+++ b/src/it/install-from-local-repo/to-copy/pom.xml
@@ -40,7 +40,7 @@
 	<name>An example artifact to test support for local repositories</name>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/../target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/../target/ImageJ.app/</scijava.app.directory>
 	</properties>
 
 	<dependencies>
@@ -72,7 +72,7 @@
 							<goal>install-artifact</goal>
 						</goals>
 						<configuration>
-							<imagejDirectory>${project.basedir}/../target/Other.app/</imagejDirectory>
+							<appDirectory>${project.basedir}/../target/Other.app/</appDirectory>
 							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
 						</configuration>
 					</execution>

--- a/src/it/install-from-local-repo/to-copy/pom.xml
+++ b/src/it/install-from-local-repo/to-copy/pom.xml
@@ -1,0 +1,83 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>to-copy</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example artifact to test support for local repositories</name>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/../target/ImageJ.app/</imagej.app.directory>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>only-local</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<imagejDirectory>${project.basedir}/../target/Other.app/</imagejDirectory>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/install-from-local-repo/verify.bsh
+++ b/src/it/install-from-local-repo/verify.bsh
@@ -1,0 +1,40 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+// copy-jars
+jars = new File(ijDir, "jars");
+assertTrue("Should have to-copy.jar", new File(jars, "to-copy-1.0.0-SNAPSHOT.jar").exists());
+assertTrue("Should have only-local.jar", new File(jars, "only-local-1.0.0-SNAPSHOT.jar").exists());
+
+// install-artifact
+assertTrue("Should have to-copy.jar", new File(ijDir, "../Other.app/jars/to-copy-1.0.0-SNAPSHOT.jar").exists());
+assertTrue("Should have only-local.jar", new File(ijDir, "../Other.app/jars/only-local-1.0.0-SNAPSHOT.jar").exists());

--- a/src/it/install-from-local-repo/verify.bsh
+++ b/src/it/install-from-local-repo/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/lib.bsh
+++ b/src/it/lib.bsh
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+
+assertTrue(message, condition) {
+	if (!condition) {
+		System.err.println(message);
+		throw new RuntimeException("Failure!");
+	}
+}
+
+assertLogContains(needle) {
+	buildLog = readFile(new File(basedir, "build.log"));
+	assertTrue("Should contain '" + needle + "':\n" + buildLog,
+		buildLog.contains(needle));
+}
+
+readFile(file) {
+	builder = new StringBuilder();
+	reader = new BufferedReader(new FileReader(file));
+	for (;;) {
+		line = reader.readLine();
+		if (line == null) break;
+		builder.append("> ").append(line).append("\n");
+	}
+	return builder.toString();
+}
+
+touchFile(file) {
+	if (file.exists()) {
+		file.setLastModified(System.currentTimeMillis());
+	} else {
+		new FileWriter(file).close();
+	}
+}
+
+target = new File(basedir, "target");
+ijDir = new File(target, "ImageJ.app");
+plugins = new File(ijDir, "plugins");
+plugin = new File(plugins, "Example_PlugIn-1.0.0-SNAPSHOT.jar");
+
+//assertTrue("Is a directory: " + target, target.isDirectory());

--- a/src/it/lib.bsh
+++ b/src/it/lib.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/missing-property/pom.xml
+++ b/src/it/missing-property/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/missing-property/pom.xml
+++ b/src/it/missing-property/pom.xml
@@ -1,0 +1,71 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.48s</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>test</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/missing-property/verify.bsh
+++ b/src/it/missing-property/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/missing-property/verify.bsh
+++ b/src/it/missing-property/verify.bsh
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should not exist: " + ijDir, !ijDir.exists());
+
+buildLog = readFile(new File(basedir, "build.log"));
+assertTrue("Should contain 'Skipping copy-jars':\n" + buildLog,
+	buildLog.contains("Skipping copy-jars"));

--- a/src/it/no-nag/pom.xml
+++ b/src/it/no-nag/pom.xml
@@ -1,0 +1,63 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Not_A_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example project without ImageJ 1.x dependency to test the CopyJarsMojo</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>test</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/no-nag/pom.xml
+++ b/src/it/no-nag/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/no-nag/verify.bsh
+++ b/src/it/no-nag/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/no-nag/verify.bsh
+++ b/src/it/no-nag/verify.bsh
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should not exist: " + ijDir, !ijDir.exists());
+
+buildLog = readFile(new File(basedir, "build.log"));
+assertTrue("Should not contain 'Skipping copy-jars':\n" + buildLog,
+	!buildLog.contains("Skipping copy-jars"));

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/skip-copy-jars/pom.xml
+++ b/src/it/skip-copy-jars/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/skip-copy-jars/pom.xml
+++ b/src/it/skip-copy-jars/pom.xml
@@ -1,0 +1,72 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test scijava-maven-plugin's CopyJarsMojo</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.48s</version>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>copy-jars</id>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-jars</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/skip-copy-jars/pom.xml
+++ b/src/it/skip-copy-jars/pom.xml
@@ -47,7 +47,7 @@
 	</dependencies>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/src/it/skip-copy-jars/verify.bsh
+++ b/src/it/skip-copy-jars/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/skip-copy-jars/verify.bsh
+++ b/src/it/skip-copy-jars/verify.bsh
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+assertTrue("Should not exist: " + ijDir, !ijDir.exists());
+
+buildLog = readFile(new File(basedir, "build.log"));
+assertTrue("Should contain 'Skipping copy-jars':\n" + buildLog,
+	buildLog.contains("Skipping copy-jars"));

--- a/src/it/skip-optional/pom.xml
+++ b/src/it/skip-optional/pom.xml
@@ -1,0 +1,76 @@
+<!--
+  #%L
+  ImageJ software for multidimensional image processing and analysis.
+  %%
+  Copyright (C) 2012 - 2016 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+  Institute of Molecular Cell Biology and Genetics.
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>Example_PlugIn</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>An example ImageJ 1.x plugin to test imagej-maven-plugin's install-artifact goal</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.48s</version>
+			<optional>true</optional>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.scijava</groupId>
+				<artifactId>scijava-maven-plugin</artifactId>
+				<version>${scijava-maven.version}</version>
+				<executions>
+					<execution>
+						<id>install-artifact</id>
+						<phase>install</phase>
+						<goals>
+							<goal>install-artifact</goal>
+						</goals>
+						<configuration>
+							<artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/skip-optional/pom.xml
+++ b/src/it/skip-optional/pom.xml
@@ -1,10 +1,10 @@
 <!--
   #%L
-  ImageJ software for multidimensional image processing and analysis.
+  A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2012 - 2016 Board of Regents of the University of
-  Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
-  Institute of Molecular Cell Biology and Genetics.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/it/skip-optional/pom.xml
+++ b/src/it/skip-optional/pom.xml
@@ -48,7 +48,7 @@
 	</dependencies>
 
 	<properties>
-		<imagej.app.directory>${project.basedir}/target/ImageJ.app/</imagej.app.directory>
+		<scijava.app.directory>${project.basedir}/target/ImageJ.app/</scijava.app.directory>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/src/it/skip-optional/setup.bsh
+++ b/src/it/skip-optional/setup.bsh
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+if (!plugins.exists()) plugins.mkdirs();

--- a/src/it/skip-optional/setup.bsh
+++ b/src/it/skip-optional/setup.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/it/skip-optional/verify.bsh
+++ b/src/it/skip-optional/verify.bsh
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+source(new File(basedir, "../../../src/it/lib.bsh").getPath());
+
+// it must copy the optional ij dependency
+ij = new File(ijDir, "jars/ij-1.48s.jar");
+assertTrue("ImageJ 1.x was copied although optional: " + ij, !ij.exists());

--- a/src/it/skip-optional/verify.bsh
+++ b/src/it/skip-optional/verify.bsh
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/AbstractSciJavaDependencyChecker.java
+++ b/src/main/java/org/scijava/maven/plugin/AbstractSciJavaDependencyChecker.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/BumpMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/BumpMojo.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/DependencyUtils.java
+++ b/src/main/java/org/scijava/maven/plugin/DependencyUtils.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/EclipseHelperMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/EclipseHelperMojo.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/SciJavaDependencyChecker.java
+++ b/src/main/java/org/scijava/maven/plugin/SciJavaDependencyChecker.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/SciJavaDependencyException.java
+++ b/src/main/java/org/scijava/maven/plugin/SciJavaDependencyException.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/SetRootDirPropertyMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/SetRootDirPropertyMojo.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/SnapshotFinder.java
+++ b/src/main/java/org/scijava/maven/plugin/SnapshotFinder.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/VerifyNoSnapshotsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/VerifyNoSnapshotsMojo.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/VerifyNoSnapshotsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/VerifyNoSnapshotsMojo.java
@@ -39,6 +39,8 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
@@ -57,10 +59,8 @@ import org.apache.maven.shared.dependency.tree.DependencyTreeBuilder;
  * are specified.</li>
  * </ul>
  * </p>
- *
- * @goal verify-no-snapshots
- * @phase validate
  */
+@Mojo(name = "verify-no-snapshots", defaultPhase = LifecyclePhase.VALIDATE)
 public class VerifyNoSnapshotsMojo extends AbstractMojo {
 
 	// -- Parameters --

--- a/src/main/java/org/scijava/maven/plugin/enforcer/RequireElements.java
+++ b/src/main/java/org/scijava/maven/plugin/enforcer/RequireElements.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/enforcer/RequireReproducibleBuilds.java
+++ b/src/main/java/org/scijava/maven/plugin/enforcer/RequireReproducibleBuilds.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
@@ -50,8 +50,13 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.interpolation.EnvarBasedValueSource;
 import org.codehaus.plexus.interpolation.ObjectBasedValueSource;
 import org.codehaus.plexus.interpolation.PrefixAwareRecursionInterceptor;
@@ -70,6 +75,95 @@ import org.scijava.util.VersionUtils;
  */
 public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 
+	/**
+	 * Path to the ImageJ.app/ directory to which artifacts are copied.
+	 * <p>
+	 * If it is not a directory, no .jar files are copied.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = imagejDirectoryProperty, required = false)
+	String imagejDirectory;
+
+	/**
+	 * Path to a SciJava application directory (e.g. ImageJ.app) to which
+	 * artifacts are copied.
+	 * <p>
+	 * If it is not a directory, no .jar files are copied.
+	 * </p>
+	 */
+	@Parameter(property = appDirectoryProperty, required = false)
+	String appDirectory;
+
+	/**
+	 * The name of the property pointing to the subdirectory (beneath e.g.
+	 * {@code jars/} or {@code plugins/}) to which the artifact should be copied.
+	 * <p>
+	 * If no property of that name exists, no subdirectory will be used.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = imagejSubdirectoryProperty, required = false)
+	String imagejSubdirectory;
+
+	/**
+	 * The name of the property pointing to the subdirectory (beneath e.g.
+	 * {@code jars/} or {@code plugins/}) to which the artifact should be copied.
+	 * <p>
+	 * If no property of that name exists, no subdirectory will be used.
+	 * </p>
+	 */
+	@Parameter(property = appSubdirectoryProperty, required = false)
+	String appSubdirectory;
+
+	/**
+	 * Whether to delete other versions when copying the files.
+	 * <p>
+	 * When copying a file and its dependencies to an ImageJ.app/ directory and
+	 * there are other versions of the same file, we can warn or delete those
+	 * other versions.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = deleteOtherVersionsProperty)
+	boolean deleteOtherVersions;
+
+	/**
+	 * Whether to delete other versions when copying the files.
+	 * <p>
+	 * When copying a file and its dependencies to an ImageJ.app/ directory and
+	 * there are other versions of the same file, we can warn or delete those
+	 * other versions.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = imagejDeleteOtherVersionsPolicyProperty)
+	OtherVersions imagejDeleteOtherVersionsPolicy;
+
+	/**
+	 * Whether to delete other versions when copying the files.
+	 * <p>
+	 * When copying a file and its dependencies to a SciJava application directory
+	 * and there are other versions of the same file, we can warn or delete those
+	 * other versions.
+	 * </p>
+	 */
+	@Parameter(property = deleteOtherVersionsPolicyProperty, defaultValue = "older")
+	OtherVersions deleteOtherVersionsPolicy;
+
+	/**
+	 * If this option is set to <code>true</code>, only the artifact will be
+	 * copied - without its dependencies.
+	 */
+	@Parameter(property = ignoreDependenciesProperty, defaultValue = "false")
+	boolean ignoreDependencies;
+
+	@Parameter(defaultValue = "${session}")
+	MavenSession session;
+
+	@Parameter( defaultValue = "${mojoExecution}", readonly = true )
+	MojoExecution mojoExecution;
+
 	public static final String imagejDirectoryProperty = "imagej.app.directory";
 	public static final String imagejSubdirectoryProperty = "imagej.app.subdirectory";
 	public static final String deleteOtherVersionsProperty = "delete.other.versions";
@@ -82,6 +176,65 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 
 	public enum OtherVersions {
 			always, older, never
+	}
+
+	/**
+	 * Handles the backward compatibility with properties previously defined by
+	 * imagej-maven-plugin.
+	 */
+	void handleBackwardCompatibility() {
+		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
+
+		try {
+			// If at least one scijava.* property is set, ignore imagej.* properties
+			if (evaluator.evaluate("${" + appDirectoryProperty + "}") == null &&
+				evaluator.evaluate("${" + appSubdirectoryProperty + "}") == null &&
+				evaluator.evaluate("${" + deleteOtherVersionsPolicyProperty + "}") == null)
+			{
+
+				// Keep backwards compatibility to delete.other.versions
+				if (evaluator.evaluate("${"+deleteOtherVersionsProperty+"}") != null) {
+					getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+					deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
+				}
+
+				// Keep backwards compatibility to imagej.app.directory
+				// Use imagejDirectory if it is set (directly or via imagej.app.directory)
+				if (imagejDirectory != null) {
+					if (evaluator.evaluate("${"+imagejDirectoryProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejDirectory' is deprecated. Use 'appDirectory' instead");
+					} else {
+						getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
+					}
+					appDirectory = imagejDirectory;
+				}
+
+				// Keep backwards compatibility to imagej.app.subdirectory
+				// Use imagejSubdirectory if it is set (directly or via imagej.app.subdirectory)
+				if (imagejSubdirectory != null) {
+					if (evaluator.evaluate("${"+imagejSubdirectoryProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejSubdirectory' is deprecated. Use 'appSubdirectory' instead");
+					} else {
+						getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
+					}
+					appSubdirectory = imagejSubdirectory;
+				}
+
+				// Keep backwards compatibility to imagej.deleteOtherVersions
+				// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via imagej.deleteOtherVersions)
+				if (imagejDeleteOtherVersionsPolicy != null) {
+					if (evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated. Use 'deleteOtherVersionsPolicy' instead");
+					} else {
+						getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+					}
+					deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
+				}
+			}
+		}
+		catch (ExpressionEvaluationException e) {
+			getLog().warn(e);
+		}
 	}
 
 	protected boolean hasIJ1Dependency(final MavenProject project) {

--- a/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
@@ -1,0 +1,311 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.maven.plugin.install;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.interpolation.EnvarBasedValueSource;
+import org.codehaus.plexus.interpolation.ObjectBasedValueSource;
+import org.codehaus.plexus.interpolation.PrefixAwareRecursionInterceptor;
+import org.codehaus.plexus.interpolation.PrefixedValueSourceWrapper;
+import org.codehaus.plexus.interpolation.PropertiesBasedValueSource;
+import org.codehaus.plexus.interpolation.RecursionInterceptor;
+import org.codehaus.plexus.interpolation.RegexBasedInterpolator;
+import org.codehaus.plexus.util.FileUtils;
+import org.scijava.util.VersionUtils;
+
+/**
+ * Base class for mojos to copy .jar artifacts and their dependencies into a
+ * SciJava application directory structure.
+ * 
+ * @author Johannes Schindelin
+ */
+public abstract class AbstractCopyJarsMojo extends AbstractMojo {
+
+	public static final String imagejDirectoryProperty = "imagej.app.directory";
+	public static final String imagejSubdirectoryProperty = "imagej.app.subdirectory";
+	public static final String deleteOtherVersionsProperty = "delete.other.versions";
+	public static final String imagejDeleteOtherVersionsPolicyProperty = "imagej.deleteOtherVersions";
+
+	public static final String appDirectoryProperty = "scijava.app.directory";
+	public static final String appSubdirectoryProperty = "scijava.app.subdirectory";
+	public static final String deleteOtherVersionsPolicyProperty = "scijava.deleteOtherVersions";
+	public static final String ignoreDependenciesProperty = "scijava.ignoreDependencies";
+
+	public enum OtherVersions {
+			always, older, never
+	}
+
+	protected boolean hasIJ1Dependency(final MavenProject project) {
+		final List<Dependency> dependencies = project.getDependencies();
+		for (final Dependency dependency : dependencies) {
+			final String artifactId = dependency.getArtifactId();
+			if ("ij".equals(artifactId) || "imagej".equals(artifactId)) return true;
+		}
+		return false;
+	}
+
+	protected String interpolate(final String original,
+		final MavenProject project, final MavenSession session)
+		throws MojoExecutionException
+	{
+		if (original == null || original.indexOf("${") < 0) return original;
+		try {
+			RegexBasedInterpolator interpolator = new RegexBasedInterpolator();
+
+			interpolator.addValueSource(new EnvarBasedValueSource());
+			interpolator.addValueSource(new PropertiesBasedValueSource(System
+				.getProperties()));
+
+			List<String> synonymPrefixes = new ArrayList<>();
+			synonymPrefixes.add("project.");
+			synonymPrefixes.add("pom.");
+
+			if (project != null) {
+				PrefixedValueSourceWrapper modelWrapper =
+					new PrefixedValueSourceWrapper(new ObjectBasedValueSource(project
+						.getModel()), synonymPrefixes, true);
+				interpolator.addValueSource(modelWrapper);
+
+				PrefixedValueSourceWrapper pomPropertyWrapper =
+					new PrefixedValueSourceWrapper(new PropertiesBasedValueSource(project
+						.getModel().getProperties()), synonymPrefixes, true);
+				interpolator.addValueSource(pomPropertyWrapper);
+			}
+
+			if (session != null) {
+				interpolator.addValueSource(new PropertiesBasedValueSource(session
+					.getExecutionProperties()));
+			}
+
+			RecursionInterceptor recursionInterceptor =
+				new PrefixAwareRecursionInterceptor(synonymPrefixes, true);
+			return interpolator.interpolate(original, recursionInterceptor);
+		}
+		catch (Exception e) {
+			throw new MojoExecutionException("Could not interpolate '" + original +
+				"'", e);
+		}
+	}
+
+	protected void installArtifact(final Artifact artifact,
+		final File imagejDirectory, final boolean force,
+		final OtherVersions otherVersionsPolicy) throws IOException
+	{
+		installArtifact(artifact, imagejDirectory, "", force, otherVersionsPolicy);
+	}
+
+	protected void installArtifact(final Artifact artifact,
+		final File imagejDirectory, final String subdirectory, final boolean force,
+		final OtherVersions otherVersionsPolicy) throws IOException
+	{
+		if (!"jar".equals(artifact.getType())) return;
+
+		final File source = artifact.getFile();
+		final File targetDirectory;
+
+		if (subdirectory != null && !subdirectory.equals("")) {
+			targetDirectory = new File(imagejDirectory, subdirectory);
+		} else if (isIJ1Plugin(source)) {
+			targetDirectory = new File(imagejDirectory, "plugins");
+		}
+		else if ("ome".equals(artifact.getGroupId()) ||
+			("loci".equals(artifact.getGroupId()) && (source.getName().startsWith(
+				"scifio-4.4.") || source.getName().startsWith("jai_imageio-4.4."))))
+		{
+			targetDirectory = new File(imagejDirectory, "jars/bio-formats");
+		}
+		else {
+			targetDirectory = new File(imagejDirectory, "jars");
+		}
+		final String fileName = "Fiji_Updater".equals(artifact.getArtifactId())
+			? artifact.getArtifactId() + ".jar" : source.getName();
+		final File target = new File(targetDirectory, fileName);
+
+		boolean newerVersion = false;
+		final Path directoryPath = Paths.get(imagejDirectory.toURI());
+		final Path targetPath = Paths.get(target.toURI());
+		final Collection<Path> otherVersions = //
+			getEncroachingVersions(directoryPath, targetPath);
+		if (otherVersions != null && !otherVersions.isEmpty()) {
+			for (final Path other : otherVersions) {
+				final Path otherName = other.getFileName();
+				switch (otherVersionsPolicy) {
+					case never:
+						getLog().warn("Possibly incompatible version exists: " + otherName);
+						break;
+					case older:
+						final String toInstall = artifact.getVersion();
+						final Matcher matcher = versionPattern.matcher(otherName.toString());
+						if (!matcher.matches()) break;
+						final String group = matcher.group(VERSION_INDEX);
+						if (group == null) {
+							newerVersion = true;
+							getLog().warn("Impenetrable version suffix for file: " +
+								otherName);
+						}
+						else {
+							final String otherVersion = group.substring(1);
+							newerVersion = VersionUtils.compare(toInstall, otherVersion) < 0;
+							if (majorVersion(toInstall) != majorVersion(otherVersion)) {
+								getLog().warn(
+									"Found other version that is incompatible according to SemVer: " +
+										otherVersion);
+							}
+						}
+						if (newerVersion) break;
+						//$FALL-THROUGH$
+					case always:
+						if (Files.deleteIfExists(other)) {
+							getLog().info("Deleted overridden " + otherName);
+							newerVersion = false;
+						}
+						else getLog().warn("Could not delete overridden " + otherName);
+						break;
+				}
+			}
+		}
+
+		if (!force && target.exists() &&
+			target.lastModified() > source.lastModified())
+		{
+			getLog().info("Dependency " + fileName + " is already there; skipping");
+		}
+		else if (newerVersion) {
+			getLog().info("A newer version for " + fileName + " was detected; skipping");
+		}
+		else {
+			getLog().info("Copying " + fileName + " to " + targetDirectory);
+			FileUtils.copyFile(source, target);
+		}
+	}
+
+	private static boolean isIJ1Plugin(final File file) {
+		final String name = file.getName();
+		if (name.indexOf('_') < 0 || !file.exists()) return false;
+		if (file.isDirectory()) {
+			return new File(file, "src/main/resources/plugins.config").exists();
+		}
+		if (!name.endsWith(".jar")) return false;
+
+		try (final JarFile jar = new JarFile(file)) {
+			for (final JarEntry entry : Collections.list(jar.entries())) {
+				if (entry.getName().equals("plugins.config")) {
+					jar.close();
+					return true;
+				}
+			}
+		}
+		catch (final Throwable t) {
+			// obviously not a plugin...
+		}
+		return false;
+	}
+
+	private final static Pattern versionPattern = Pattern.compile("(.+?)"
+		+ "(-\\d+(\\.\\d+|\\d{7})+[a-z]?\\d?(-[A-Za-z0-9.]+?|\\.GA)*?)?"
+		+ "((-(swing|swt|sources|javadoc|native|linux-x86|linux-x86_64|macosx-x86_64|windows-x86|windows-x86_64|android-arm|android-x86|natives-windows|natives-macos|natives-linux))?(\\.jar(-[a-z]*)?))");
+	private final static int PREFIX_INDEX = 1;
+	private final static int VERSION_INDEX = 2;
+	private final static int SUFFIX_INDEX = 5;
+
+	/**
+	 * Extracts the major version (according to SemVer) from a version string.
+	 * If no dot is found, the input is returned.
+	 * 
+	 * @param v
+	 *            SemVer version string
+	 * @return The major version (according to SemVer) as {@code String}.
+	 */
+	private String majorVersion( String v )
+	{
+	final int dot = v.indexOf('.');
+	return dot < 0 ? v : v.substring(0, dot);
+	}
+
+	/**
+	 * Looks for files in {@code directory} with the same base name as
+	 * {@code file}.
+	 *
+	 * @param directory The directory to walk to find possible duplicates.
+	 * @param file A {@link Path} to the target (from which the base name is
+	 *          derived).
+	 * @return A collection of {@link Path}s to files of the same base name.
+	 */
+	private Collection<Path> getEncroachingVersions(final Path directory, final Path file) {
+		final Matcher matcher = versionPattern.matcher(file.getFileName().toString());
+		if (!matcher.matches()) return null;
+
+		final String prefix = matcher.group(PREFIX_INDEX);
+		final String suffix = matcher.group(SUFFIX_INDEX);
+
+		Collection<Path> result = new ArrayList<>();
+		try {
+			result = Files.walk(directory)
+			.filter(path -> path.getFileName().toString().startsWith(prefix))
+			.filter(path -> {
+				final Matcher matcherIterator = versionPattern.matcher(path.getFileName().toString());
+				return matcherIterator.matches() &&
+					prefix.equals(matcherIterator.group(PREFIX_INDEX)) &&
+					suffix.equals(matcherIterator.group(SUFFIX_INDEX));
+			})
+			.filter(path -> !path.getFileName().toString().equals(file.getFileName().toString()))
+			.collect(Collectors.toCollection(ArrayList::new));
+			return result;
+		} catch (IOException e) {
+			getLog().error(e);
+		} finally {
+			result = new ArrayList<>();
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
@@ -183,55 +183,87 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 	 * imagej-maven-plugin.
 	 */
 	void handleBackwardCompatibility() {
-		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
+		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(
+			session, mojoExecution);
 
 		try {
 			// If at least one scijava.* property is set, ignore imagej.* properties
 			if (evaluator.evaluate("${" + appDirectoryProperty + "}") == null &&
 				evaluator.evaluate("${" + appSubdirectoryProperty + "}") == null &&
-				evaluator.evaluate("${" + deleteOtherVersionsPolicyProperty + "}") == null)
+				evaluator.evaluate("${" + deleteOtherVersionsPolicyProperty +
+					"}") == null)
 			{
 
 				// Keep backwards compatibility to delete.other.versions
-				if (evaluator.evaluate("${"+deleteOtherVersionsProperty+"}") != null) {
-					getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
-					deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
+				if (evaluator.evaluate("${" + deleteOtherVersionsProperty +
+					"}") != null)
+				{
+					getLog().warn("Property '" + deleteOtherVersionsProperty +
+						"' is deprecated. Use '" + deleteOtherVersionsPolicyProperty +
+						"' instead");
+					deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older
+						: OtherVersions.never;
 				}
 
 				// Keep backwards compatibility to imagej.app.directory
-				// Use imagejDirectory if it is set (directly or via imagej.app.directory)
+				// Use imagejDirectory if it is set (directly or via
+				// imagej.app.directory)
 				if (imagejDirectory != null) {
-					if (evaluator.evaluate("${"+imagejDirectoryProperty+"}") == null) {
-						getLog().warn("Configuration property 'imagejDirectory' is deprecated. Use 'appDirectory' instead");
-					} else {
-						getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
+					if (evaluator.evaluate("${" + imagejDirectoryProperty +
+						"}") == null)
+					{
+						getLog().warn(
+							"Configuration property 'imagejDirectory' is deprecated." +
+								"Use 'appDirectory' instead");
+					}
+					else {
+						getLog().warn("Property '" + imagejDirectoryProperty +
+							"' is deprecated. Use '" + appDirectoryProperty + "' instead");
 					}
 					appDirectory = imagejDirectory;
 				}
 
 				// Keep backwards compatibility to imagej.app.subdirectory
-				// Use imagejSubdirectory if it is set (directly or via imagej.app.subdirectory)
+				// Use imagejSubdirectory if it is set (directly or via
+				// imagej.app.subdirectory)
 				if (imagejSubdirectory != null) {
-					if (evaluator.evaluate("${"+imagejSubdirectoryProperty+"}") == null) {
-						getLog().warn("Configuration property 'imagejSubdirectory' is deprecated. Use 'appSubdirectory' instead");
-					} else {
-						getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
+					if (evaluator.evaluate("${" + imagejSubdirectoryProperty +
+						"}") == null)
+					{
+						getLog().warn(
+							"Configuration property 'imagejSubdirectory' is deprecated." +
+								"Use 'appSubdirectory' instead");
+					}
+					else {
+						getLog().warn("Property '" + imagejSubdirectoryProperty +
+							"' is deprecated. Use '" + appSubdirectoryProperty + "' instead");
 					}
 					appSubdirectory = imagejSubdirectory;
 				}
 
 				// Keep backwards compatibility to imagej.deleteOtherVersions
-				// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via imagej.deleteOtherVersions)
+				// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via
+				// imagej.deleteOtherVersions)
 				if (imagejDeleteOtherVersionsPolicy != null) {
-					if (evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}") == null) {
-						getLog().warn("Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated. Use 'deleteOtherVersionsPolicy' instead");
-					} else {
-						getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+					if (evaluator.evaluate("${" +
+						imagejDeleteOtherVersionsPolicyProperty + "}") == null)
+					{
+						getLog().warn(
+							"Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated." +
+								"Use 'deleteOtherVersionsPolicy' instead");
+					}
+					else {
+						getLog().warn("Property '" +
+							imagejDeleteOtherVersionsPolicyProperty +
+							"' is deprecated. Use '" + deleteOtherVersionsPolicyProperty +
+							"' instead");
 					}
 					deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
 				}
-			} else {
-				getLog().info("At least one scijava.* property is set. Ignoring imagej.* properties");
+			}
+			else {
+				getLog().info(
+					"At least one scijava.* property is set. Ignoring imagej.* properties");
 			}
 		}
 		catch (ExpressionEvaluationException e) {
@@ -292,14 +324,14 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 	}
 
 	protected void installArtifact(final Artifact artifact,
-		final File imagejDirectory, final boolean force,
+		final File appDirectory, final boolean force,
 		final OtherVersions otherVersionsPolicy) throws IOException
 	{
-		installArtifact(artifact, imagejDirectory, "", force, otherVersionsPolicy);
+		installArtifact(artifact, appDirectory, "", force, otherVersionsPolicy);
 	}
 
 	protected void installArtifact(final Artifact artifact,
-		final File imagejDirectory, final String subdirectory, final boolean force,
+		final File appDirectory, final String appSubdirectory, final boolean force,
 		final OtherVersions otherVersionsPolicy) throws IOException
 	{
 		if (!"jar".equals(artifact.getType())) return;
@@ -307,26 +339,26 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 		final File source = artifact.getFile();
 		final File targetDirectory;
 
-		if (subdirectory != null && !subdirectory.equals("")) {
-			targetDirectory = new File(imagejDirectory, subdirectory);
+		if (appSubdirectory != null && !appSubdirectory.equals("")) {
+			targetDirectory = new File(appDirectory, appSubdirectory);
 		} else if (isIJ1Plugin(source)) {
-			targetDirectory = new File(imagejDirectory, "plugins");
+			targetDirectory = new File(appDirectory, "plugins");
 		}
 		else if ("ome".equals(artifact.getGroupId()) ||
 			("loci".equals(artifact.getGroupId()) && (source.getName().startsWith(
 				"scifio-4.4.") || source.getName().startsWith("jai_imageio-4.4."))))
 		{
-			targetDirectory = new File(imagejDirectory, "jars/bio-formats");
+			targetDirectory = new File(appDirectory, "jars/bio-formats");
 		}
 		else {
-			targetDirectory = new File(imagejDirectory, "jars");
+			targetDirectory = new File(appDirectory, "jars");
 		}
 		final String fileName = "Fiji_Updater".equals(artifact.getArtifactId())
 			? artifact.getArtifactId() + ".jar" : source.getName();
 		final File target = new File(targetDirectory, fileName);
 
 		boolean newerVersion = false;
-		final Path directoryPath = Paths.get(imagejDirectory.toURI());
+		final Path directoryPath = Paths.get(appDirectory.toURI());
 		final Path targetPath = Paths.get(target.toURI());
 		final Collection<Path> otherVersions = //
 			getEncroachingVersions(directoryPath, targetPath);
@@ -422,8 +454,8 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 	 */
 	private String majorVersion( String v )
 	{
-	final int dot = v.indexOf('.');
-	return dot < 0 ? v : v.substring(0, dot);
+		final int dot = v.indexOf('.');
+		return dot < 0 ? v : v.substring(0, dot);
 	}
 
 	/**

--- a/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/AbstractCopyJarsMojo.java
@@ -230,6 +230,8 @@ public abstract class AbstractCopyJarsMojo extends AbstractMojo {
 					}
 					deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
 				}
+			} else {
+				getLog().info("At least one scijava.* property is set. Ignoring imagej.* properties");
 			}
 		}
 		catch (ExpressionEvaluationException e) {

--- a/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
@@ -133,7 +133,7 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 	 * </p>
 	 */
 	@Deprecated
-	@Parameter(property = imagejDeleteOtherVersionsPolicyProperty, defaultValue = "older")
+	@Parameter(property = imagejDeleteOtherVersionsPolicyProperty)
 	private OtherVersions imagejDeleteOtherVersionsPolicy;
 
 	/**
@@ -198,8 +198,14 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 		// Keep backwards compatibility to imagej.app.directory
 		try {
 			Object evaluate = evaluator.evaluate("${"+imagejDirectoryProperty+"}");
-			if (evaluate != null) {
-				getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
+
+			// Use imagejDirectory if it is set (directly or via imagej.app.directory)
+			if (imagejDirectory != null) {
+				if (evaluate == null) {
+					getLog().warn("Configuration property 'imagejDirectory' is deprecated. Use 'appDirectory' instead");
+				} else {
+					getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
+				}
 
 				// TODO How do we want to handle cases where both are provided. Which
 				// property should take precedence?
@@ -213,8 +219,14 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 		// Keep backwards compatibility to imagej.app.subdirectory
 		try {
 			Object evaluate = evaluator.evaluate("${"+imagejSubdirectoryProperty+"}");
-			if (evaluate != null) {
-				getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
+			
+			// Use imagejSubdirectory if it is set (directly or via imagej.app.subdirectory)
+			if (imagejSubdirectory != null) {
+				if (evaluate == null) {
+					getLog().warn("Configuration property 'imagejSubdirectory' is deprecated. Use 'appSubdirectory' instead");
+				} else {
+					getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
+				}
 
 				// TODO How do we want to handle cases where both are provided. Which
 				// property should take precedence?
@@ -228,8 +240,14 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 		// Keep backwards compatibility to imagej.deleteOtherVersions
 		try {
 			Object evaluate = evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}");
-			if (evaluate != null) {
-				getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+
+			// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via imagej.deleteOtherVersions)
+			if (imagejDeleteOtherVersionsPolicy != null) {
+				if (evaluate == null) {
+					getLog().warn("Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated. Use 'deleteOtherVersionsPolicy' instead");
+				} else {
+					getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+				}
 
 				// TODO How do we want to handle cases where both are provided. Which
 				// property should take precedence?

--- a/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
@@ -181,82 +181,8 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException {
-		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
-
-		// Keep backwards compatibility to delete.other.versions
-		try {
-			Object evaluate = evaluator.evaluate("${"+deleteOtherVersionsProperty+"}");
-			if (evaluate != null) {
-				getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
-				deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
-		}
-
-		// Keep backwards compatibility to imagej.app.directory
-		try {
-			Object evaluate = evaluator.evaluate("${"+imagejDirectoryProperty+"}");
-
-			// Use imagejDirectory if it is set (directly or via imagej.app.directory)
-			if (imagejDirectory != null) {
-				if (evaluate == null) {
-					getLog().warn("Configuration property 'imagejDirectory' is deprecated. Use 'appDirectory' instead");
-				} else {
-					getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
-				}
-
-				// TODO How do we want to handle cases where both are provided. Which
-				// property should take precedence?
-				appDirectory = imagejDirectory;
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
-		}
-
-		// Keep backwards compatibility to imagej.app.subdirectory
-		try {
-			Object evaluate = evaluator.evaluate("${"+imagejSubdirectoryProperty+"}");
-			
-			// Use imagejSubdirectory if it is set (directly or via imagej.app.subdirectory)
-			if (imagejSubdirectory != null) {
-				if (evaluate == null) {
-					getLog().warn("Configuration property 'imagejSubdirectory' is deprecated. Use 'appSubdirectory' instead");
-				} else {
-					getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
-				}
-
-				// TODO How do we want to handle cases where both are provided. Which
-				// property should take precedence?
-				appSubdirectory = imagejSubdirectory;
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
-		}
-
-		// Keep backwards compatibility to imagej.deleteOtherVersions
-		try {
-			Object evaluate = evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}");
-
-			// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via imagej.deleteOtherVersions)
-			if (imagejDeleteOtherVersionsPolicy != null) {
-				if (evaluate == null) {
-					getLog().warn("Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated. Use 'deleteOtherVersionsPolicy' instead");
-				} else {
-					getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
-				}
-
-				// TODO How do we want to handle cases where both are provided. Which
-				// property should take precedence?
-				deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
-		}
+		// Keep backwards compatibility
+		handleBackwardsCompatibility();
 
 		if (appDirectory == null) {
 			if (hasIJ1Dependency(project)) getLog().info(
@@ -313,6 +239,64 @@ public class CopyJarsMojo extends AbstractCopyJarsMojo {
 		catch (DependencyResolverException e) {
 			throw new MojoExecutionException(
 				"Couldn't resolve dependencies for artifact: " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * TODO Javadoc
+	 */
+	private void handleBackwardsCompatibility() {
+		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
+
+		try {
+			// If at least one scijava.* property is set, ignore imagej.* properties
+			if (evaluator.evaluate("${" + appDirectoryProperty + "}") == null &&
+				evaluator.evaluate("${" + appSubdirectoryProperty + "}") == null &&
+				evaluator.evaluate("${" + deleteOtherVersionsPolicyProperty + "}") == null)
+			{
+
+				// Keep backwards compatibility to delete.other.versions
+				if (evaluator.evaluate("${"+deleteOtherVersionsProperty+"}") != null) {
+					getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+					deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
+				}
+
+				// Keep backwards compatibility to imagej.app.directory
+				// Use imagejDirectory if it is set (directly or via imagej.app.directory)
+				if (imagejDirectory != null) {
+					if (evaluator.evaluate("${"+imagejDirectoryProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejDirectory' is deprecated. Use 'appDirectory' instead");
+					} else {
+						getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
+					}
+					appDirectory = imagejDirectory;
+				}
+
+				// Keep backwards compatibility to imagej.app.subdirectory
+				// Use imagejSubdirectory if it is set (directly or via imagej.app.subdirectory)
+				if (imagejSubdirectory != null) {
+					if (evaluator.evaluate("${"+imagejSubdirectoryProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejSubdirectory' is deprecated. Use 'appSubdirectory' instead");
+					} else {
+						getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
+					}
+					appSubdirectory = imagejSubdirectory;
+				}
+
+				// Keep backwards compatibility to imagej.deleteOtherVersions
+				// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via imagej.deleteOtherVersions)
+				if (imagejDeleteOtherVersionsPolicy != null) {
+					if (evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated. Use 'deleteOtherVersionsPolicy' instead");
+					} else {
+						getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+					}
+					deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
+				}
+			}
+		}
+		catch (ExpressionEvaluationException e) {
+			getLog().warn(e);
 		}
 	}
 }

--- a/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
@@ -57,6 +57,14 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator
  * Copies .jar artifacts and their dependencies into a SciJava application
  * directory structure.
  * 
+ * ImageJ 1.x plugins (identified by containing a plugins.config file) get
+ * copied to the plugins/ subdirectory and all other .jar files to jars/.
+ * However, you can override this decision by setting the scijava.app.subdirectory
+ * property to a specific subdirectory. It expects the location of the SciJava
+ * application directory to be specified in the scijava.app.directory property
+ * (which can be set on the Maven command-line). If said property is not set,
+ * the copy-jars goal is skipped.
+ * 
  * @author Johannes Schindelin
  * @author Stefan Helfrich
  */

--- a/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/CopyJarsMojo.java
@@ -1,0 +1,292 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.maven.plugin.install;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.artifact.filter.resolve.ScopeFilter;
+import org.apache.maven.shared.artifact.filter.resolve.TransformableFilter;
+import org.apache.maven.shared.artifact.resolve.ArtifactResult;
+import org.apache.maven.shared.dependencies.DefaultDependableCoordinate;
+import org.apache.maven.shared.dependencies.resolve.DependencyResolver;
+import org.apache.maven.shared.dependencies.resolve.DependencyResolverException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+
+/**
+ * Copies .jar artifacts and their dependencies into a SciJava application
+ * directory structure.
+ * 
+ * @author Johannes Schindelin
+ * @author Stefan Helfrich
+ */
+@Mojo(name = "copy-jars", requiresProject = true, requiresOnline = true)
+public class CopyJarsMojo extends AbstractCopyJarsMojo {
+
+	/**
+	 * Path to the ImageJ.app/ directory to which artifacts are copied.
+	 * <p>
+	 * If it is not a directory, no .jar files are copied.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = imagejDirectoryProperty, required = false)
+	private String imagejDirectory;
+
+	/**
+	 * Path to a SciJava application directory (e.g. ImageJ.app) to which
+	 * artifacts are copied.
+	 * <p>
+	 * If it is not a directory, no .jar files are copied.
+	 * </p>
+	 */
+	@Parameter(property = appDirectoryProperty, required = false)
+	private String appDirectory;
+
+	/**
+	 * The name of the property pointing to the subdirectory (beneath e.g.
+	 * {@code jars/} or {@code plugins/}) to which the artifact should be copied.
+	 * <p>
+	 * If no property of that name exists, no subdirectory will be used.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = imagejSubdirectoryProperty, required = false)
+	private String imagejSubdirectory;
+
+	/**
+	 * The name of the property pointing to the subdirectory (beneath e.g.
+	 * {@code jars/} or {@code plugins/}) to which the artifact should be copied.
+	 * <p>
+	 * If no property of that name exists, no subdirectory will be used.
+	 * </p>
+	 */
+	@Parameter(property = appSubdirectoryProperty, required = false)
+	private String appSubdirectory;
+
+	/**
+	 * Whether to delete other versions when copying the files.
+	 * <p>
+	 * When copying a file and its dependencies to an ImageJ.app/ directory and
+	 * there are other versions of the same file, we can warn or delete those
+	 * other versions.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = deleteOtherVersionsProperty)
+	private boolean deleteOtherVersions;
+
+	/**
+	 * Whether to delete other versions when copying the files.
+	 * <p>
+	 * When copying a file and its dependencies to an ImageJ.app/ directory and
+	 * there are other versions of the same file, we can warn or delete those
+	 * other versions.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = imagejDeleteOtherVersionsPolicyProperty, defaultValue = "older")
+	private OtherVersions imagejDeleteOtherVersionsPolicy;
+
+	/**
+	 * Whether to delete other versions when copying the files.
+	 * <p>
+	 * When copying a file and its dependencies to a SciJava application directory
+	 * and there are other versions of the same file, we can warn or delete those
+	 * other versions.
+	 * </p>
+	 */
+	@Parameter(property = deleteOtherVersionsPolicyProperty, defaultValue = "older")
+	private OtherVersions deleteOtherVersionsPolicy;
+
+	/**
+	 * If this option is set to <code>true</code>, only the artifact will be
+	 * copied - without its dependencies.
+	 */
+	@Parameter(property = ignoreDependenciesProperty, defaultValue = "false")
+	private boolean ignoreDependencies;
+
+	/**
+	 * Project
+	 */
+	@Parameter(defaultValue = "${project}", required=true, readonly = true)
+	private MavenProject project;
+
+	/**
+	 * Session
+	 */
+	@Parameter(defaultValue = "${session}")
+	private MavenSession session;
+
+	/**
+	 * The dependency resolver to.
+	 */
+	@Component
+	private DependencyResolver dependencyResolver;
+
+	private DefaultDependableCoordinate coordinate = new DefaultDependableCoordinate();
+
+	private File appDir;
+
+	@Parameter( defaultValue = "${mojoExecution}", readonly = true )
+	MojoExecution mojoExecution;
+
+	@Override
+	public void execute() throws MojoExecutionException {
+		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
+
+		// Keep backwards compatibility to delete.other.versions
+		try {
+			Object evaluate = evaluator.evaluate("${"+deleteOtherVersionsProperty+"}");
+			if (evaluate != null) {
+				getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+				deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
+			}
+		}
+		catch (ExpressionEvaluationException e) {
+			getLog().warn(e);
+		}
+
+		// Keep backwards compatibility to imagej.app.directory
+		try {
+			Object evaluate = evaluator.evaluate("${"+imagejDirectoryProperty+"}");
+			if (evaluate != null) {
+				getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
+
+				// TODO How do we want to handle cases where both are provided. Which
+				// property should take precedence?
+				appDirectory = imagejDirectory;
+			}
+		}
+		catch (ExpressionEvaluationException e) {
+			getLog().warn(e);
+		}
+
+		// Keep backwards compatibility to imagej.app.subdirectory
+		try {
+			Object evaluate = evaluator.evaluate("${"+imagejSubdirectoryProperty+"}");
+			if (evaluate != null) {
+				getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
+
+				// TODO How do we want to handle cases where both are provided. Which
+				// property should take precedence?
+				appSubdirectory = imagejSubdirectory;
+			}
+		}
+		catch (ExpressionEvaluationException e) {
+			getLog().warn(e);
+		}
+
+		// Keep backwards compatibility to imagej.deleteOtherVersions
+		try {
+			Object evaluate = evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}");
+			if (evaluate != null) {
+				getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+
+				// TODO How do we want to handle cases where both are provided. Which
+				// property should take precedence?
+				deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
+			}
+		}
+		catch (ExpressionEvaluationException e) {
+			getLog().warn(e);
+		}
+
+		if (appDirectory == null) {
+			if (hasIJ1Dependency(project)) getLog().info(
+				"Property '" + appDirectoryProperty + "' unset; Skipping copy-jars");
+			return;
+		}
+		final String interpolated = interpolate(appDirectory, project, session);
+		appDir = new File(interpolated);
+
+		if (appSubdirectory == null) {
+			getLog().info("No property name for the " + appSubdirectoryProperty +
+				" directory location was specified; Installing in default location");
+		}
+
+		if (!appDir.isDirectory()) {
+			getLog().warn(
+				"'" + appDirectory + "'" +
+					(interpolated.equals(appDirectory) ? "" : " (" + appDirectory + ")") +
+					" is not an SciJava application directory; Skipping copy-jars");
+			return;
+		}
+
+		// Initialize coordinate for resolving
+		coordinate.setGroupId(project.getGroupId());
+		coordinate.setArtifactId(project.getArtifactId());
+		coordinate.setVersion(project.getVersion());
+		coordinate.setType(project.getPackaging());
+
+		try {
+			TransformableFilter scopeFilter = ScopeFilter.excluding("system", "provided", "test");
+
+			ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+			buildingRequest.setProject( project );
+
+			Iterable<ArtifactResult> resolveDependencies = dependencyResolver
+					.resolveDependencies(buildingRequest, coordinate, scopeFilter);
+				for (ArtifactResult result : resolveDependencies) {
+					try {
+						if (project.getArtifact().equals(result.getArtifact())) {
+							installArtifact(result.getArtifact(), appDir, appSubdirectory, false,
+								deleteOtherVersionsPolicy);
+							continue;
+						}
+						// Resolution of the subdirectory for dependencies is handled in installArtifact
+						if (!ignoreDependencies)
+							installArtifact(result.getArtifact(), appDir, false, deleteOtherVersionsPolicy);
+					}
+					catch (IOException e) {
+						throw new MojoExecutionException("Couldn't download artifact " +
+							result.getArtifact() + ": " + e.getMessage(), e);
+					}
+				}
+		}
+		catch (DependencyResolverException e) {
+			throw new MojoExecutionException(
+				"Couldn't resolve dependencies for artifact: " + e.getMessage(), e);
+		}
+	}
+}

--- a/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
@@ -273,82 +273,8 @@ public class InstallArtifactMojo extends AbstractCopyJarsMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
-
-		// Keep backwards compatibility to delete.other.versions
-		try {
-			Object evaluate = evaluator.evaluate("${"+deleteOtherVersionsProperty+"}");
-			if (evaluate != null) {
-				getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
-				deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
-		}
-
-		// Keep backwards compatibility to imagej.app.directory
-		try {
-			Object evaluate = evaluator.evaluate("${"+imagejDirectoryProperty+"}");
-
-			// Use imagejDirectory if it is set (directly or via imagej.app.directory)
-			if (imagejDirectory != null) {
-				if (evaluate == null) {
-					getLog().warn("Configuration property 'imagejDirectory' is deprecated. Use 'appDirectory' instead");
-				} else {
-					getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
-				}
-
-				// TODO How do we want to handle cases where both are provided. Which
-				// property should take precedence?
-				appDirectory = imagejDirectory;
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
-		}
-
-		// Keep backwards compatibility to imagej.app.subdirectory
-		try {
-			Object evaluate = evaluator.evaluate("${"+imagejSubdirectoryProperty+"}");
-			
-			// Use imagejSubdirectory if it is set (directly or via imagej.app.subdirectory)
-			if (imagejSubdirectory != null) {
-				if (evaluate == null) {
-					getLog().warn("Configuration property 'imagejSubdirectory' is deprecated. Use 'appSubdirectory' instead");
-				} else {
-					getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
-				}
-
-				// TODO How do we want to handle cases where both are provided. Which
-				// property should take precedence?
-				appSubdirectory = imagejSubdirectory;
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
-		}
-
-		// Keep backwards compatibility to imagej.deleteOtherVersions
-		try {
-			Object evaluate = evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}");
-
-			// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via imagej.deleteOtherVersions)
-			if (imagejDeleteOtherVersionsPolicy != null) {
-				if (evaluate == null) {
-					getLog().warn("Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated. Use 'deleteOtherVersionsPolicy' instead");
-				} else {
-					getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
-				}
-
-				// TODO How do we want to handle cases where both are provided. Which
-				// property should take precedence?
-				deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
-		}
+		// Keep backwards compatibility
+		handleBackwardsCompatibility();
 
 		if (appDirectory == null) {
 			throw new MojoExecutionException(
@@ -440,6 +366,64 @@ public class InstallArtifactMojo extends AbstractCopyJarsMojo {
 		catch (DependencyResolverException e) {
 			throw new MojoExecutionException(
 				"Couldn't resolve dependencies for artifact: " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * TODO Javadoc
+	 */
+	private void handleBackwardsCompatibility() {
+		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
+
+		try {
+			// If at least one scijava.* property is set, ignore imagej.* properties
+			if (evaluator.evaluate("${" + appDirectoryProperty + "}") == null &&
+				evaluator.evaluate("${" + appSubdirectoryProperty + "}") == null &&
+				evaluator.evaluate("${" + deleteOtherVersionsPolicyProperty + "}") == null)
+			{
+
+				// Keep backwards compatibility to delete.other.versions
+				if (evaluator.evaluate("${"+deleteOtherVersionsProperty+"}") != null) {
+					getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+					deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
+				}
+
+				// Keep backwards compatibility to imagej.app.directory
+				// Use imagejDirectory if it is set (directly or via imagej.app.directory)
+				if (imagejDirectory != null) {
+					if (evaluator.evaluate("${"+imagejDirectoryProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejDirectory' is deprecated. Use 'appDirectory' instead");
+					} else {
+						getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
+					}
+					appDirectory = imagejDirectory;
+				}
+
+				// Keep backwards compatibility to imagej.app.subdirectory
+				// Use imagejSubdirectory if it is set (directly or via imagej.app.subdirectory)
+				if (imagejSubdirectory != null) {
+					if (evaluator.evaluate("${"+imagejSubdirectoryProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejSubdirectory' is deprecated. Use 'appSubdirectory' instead");
+					} else {
+						getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
+					}
+					appSubdirectory = imagejSubdirectory;
+				}
+
+				// Keep backwards compatibility to imagej.deleteOtherVersions
+				// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via imagej.deleteOtherVersions)
+				if (imagejDeleteOtherVersionsPolicy != null) {
+					if (evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}") == null) {
+						getLog().warn("Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated. Use 'deleteOtherVersionsPolicy' instead");
+					} else {
+						getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
+					}
+					deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
+				}
+			}
+		}
+		catch (ExpressionEvaluationException e) {
+			getLog().warn(e);
 		}
 	}
 

--- a/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
@@ -1,10 +1,10 @@
 /*
  * #%L
- * ImageJ software for multidimensional image processing and analysis.
+ * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2012 - 2016 Board of Regents of the University of
- * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
- * Institute of Molecular Cell Biology and Genetics.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
@@ -1,0 +1,435 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2012 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.maven.plugin.install;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryFactory;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.artifact.filter.resolve.AbstractFilter;
+import org.apache.maven.shared.artifact.filter.resolve.AndFilter;
+import org.apache.maven.shared.artifact.filter.resolve.Node;
+import org.apache.maven.shared.artifact.filter.resolve.ScopeFilter;
+import org.apache.maven.shared.artifact.filter.resolve.TransformableFilter;
+import org.apache.maven.shared.artifact.resolve.ArtifactResolver;
+import org.apache.maven.shared.artifact.resolve.ArtifactResult;
+import org.apache.maven.shared.dependencies.DefaultDependableCoordinate;
+import org.apache.maven.shared.dependencies.DependableCoordinate;
+import org.apache.maven.shared.dependencies.resolve.DependencyResolver;
+import org.apache.maven.shared.dependencies.resolve.DependencyResolverException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.util.StringUtils;
+
+/**
+ * Downloads .jar artifacts and their dependencies into an ImageJ.app/ directory
+ * structure.
+ * 
+ * @author Johannes Schindelin
+ */
+@Mojo(name = "install-artifact", requiresProject=false)
+public class InstallArtifactMojo extends AbstractCopyJarsMojo {
+
+	/**
+	 * Path to the ImageJ.app/ directory to which artifacts are installed.
+	 * <p>
+	 * If it is not a directory, no .jar files are copied.
+	 * </p>
+	 */
+	@Parameter(property = imagejDirectoryProperty)
+	private String imagejDirectory;
+
+	/**
+	 * The name of the property pointing to the subdirectory (beneath e.g.
+	 * {@code jars/} or {@code plugins/}) to which the artifact should be
+	 * copied.
+	 * <p>
+	 * If no property of that name exists, no subdirectory will be used.
+	 * </p>
+	 */
+	@Parameter( property = imagejSubdirectoryProperty, required = false )
+	private String imagejSubdirectory;
+
+	/**
+	 * Whether to delete other versions when copying the files.
+	 * <p>
+	 * When copying a file and its dependencies to an ImageJ.app/ directory and
+	 * there are other versions of the same file, we can warn or delete those
+	 * other versions.
+	 * </p>
+	 */
+	@Deprecated
+	@Parameter(property = deleteOtherVersionsProperty)
+	private boolean deleteOtherVersions;
+
+	/**
+	 * Whether to delete other versions when copying the files.
+	 * <p>
+	 * When copying a file and its dependencies to an ImageJ.app/ directory and
+	 * there are other versions of the same file, we can warn or delete those
+	 * other versions.
+	 * </p>
+	 */
+	@Parameter(property = imagejDeleteOtherVersionsPolicyProperty, defaultValue = "older")
+	private OtherVersions deleteOtherVersionsPolicy;
+
+	/**
+	 * If this option is set to <code>true</code>, only the artifact will be
+	 * copied - without its dependencies.
+	 */
+	@Parameter(property = ignoreDependenciesProperty, defaultValue = "false")
+	private boolean ignoreDependencies;
+
+	/**
+	 * Session
+	 */
+	@Parameter(defaultValue = "${session}")
+	private MavenSession session;
+
+	/**
+	 * Used to look up Artifacts in the remote repository.
+	 */
+	@Component
+	private ArtifactResolver artifactResolver;
+
+	@Component
+	private ArtifactRepositoryFactory artifactRepositoryFactory;
+	
+	/**
+	 * Location of the local repository.
+	 */
+	@Parameter(property = "localRepository", readonly = true)
+	private ArtifactRepository localRepository;
+
+	/**
+	 * Map that contains the layouts.
+	 */
+	@Component(role = ArtifactRepositoryLayout.class)
+	private Map<String, ArtifactRepositoryLayout> repositoryLayouts;
+
+	private static final Pattern ALT_REPO_SYNTAX_PATTERN = Pattern.compile( "(.+)::(.*)::(.+)" );
+
+	/**
+	 * Repositories in the format id::[layout]::url or just url, separated by
+	 * comma. ie.
+	 * central::default::http://repo1.maven.apache.org/maven2,myrepo::::http://repo.acme.com,http://repo.acme2.com
+	 */
+	@Parameter(property = "remoteRepositories")
+	private String remoteRepositories;
+
+	/**
+	 * Remote repositories from POM
+	 */
+	@Parameter(defaultValue = "${project.remoteArtifactRepositories}",
+		readonly = true, required = true)
+	private List<ArtifactRepository> pomRemoteRepositories;
+
+	/**
+	 * The groupId of the artifact to download. Ignored if {@link #artifact} is
+	 * used.
+	 */
+	@Parameter(property = "groupId")
+	private String groupId;
+
+	/**
+	 * The artifactId of the artifact to download. Ignored if {@link #artifact} is
+	 * used.
+	 */
+	@Parameter(property="artifactId")
+	private String artifactId;
+
+	/**
+	 * The version of the artifact to download. Ignored if {@link #artifact} is
+	 * used.
+	 */
+	@Parameter(property="version")
+	private String version;
+
+	/**
+	 * The packaging of the artifact to download. Ignored if {@link #artifact} is
+	 * used.
+	 */
+	@Parameter(property = "packaging", defaultValue = "jar")
+	private String packaging = "jar";
+
+	/**
+	 * A string of the form groupId:artifactId:version[:packaging].
+	 */
+	@Parameter(property = "artifact")
+	private String artifact;
+
+	/**
+	 * The dependency resolver to.
+	 */
+	@Component
+	private DependencyResolver dependencyResolver;
+
+	/**
+	 * Whether to force overwriting files.
+	 */
+	@Parameter(property = "force")
+	private boolean force;
+
+	/**
+	 * The coordinate use for resolving dependencies.
+	 */
+	private DefaultDependableCoordinate coordinate = new DefaultDependableCoordinate();
+
+	@Parameter( defaultValue = "${mojoExecution}", readonly = true )
+	MojoExecution mojoExecution;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		// Keep backwards compatibility to delete.other.versions
+		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
+		try {
+			Object evaluate = evaluator.evaluate("${"+deleteOtherVersionsProperty+"}");
+			if (evaluate != null) {
+				getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ imagejDeleteOtherVersionsPolicyProperty +"' instead");
+				deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
+			}
+		}
+		catch (ExpressionEvaluationException e) {
+			getLog().warn(e);
+		}
+
+		if (imagejDirectory == null) {
+			throw new MojoExecutionException(
+				"The '"+imagejDirectoryProperty+"' property is unset!");
+		}
+		File imagejDir = new File(imagejDirectory);
+		if (!imagejDir.isDirectory() && !imagejDir.mkdirs()) {
+			throw new MojoFailureException("Could not make directory: " +
+				imagejDir);
+		}
+
+		if ( imagejSubdirectory == null )
+		{
+			getLog().info( "No property name for the " + imagejSubdirectoryProperty +
+					" directory location was specified; Installing in default location" );
+		}
+
+		ArtifactRepositoryPolicy always = new ArtifactRepositoryPolicy(true,
+			ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS,
+			ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN);
+
+		List<ArtifactRepository> repoList = new ArrayList<>();
+
+		// Use repositories provided in POM (if available)
+		if (pomRemoteRepositories != null) {
+			repoList.addAll(pomRemoteRepositories);
+		}
+
+		// Add remote repositories provided as parameter
+		if (remoteRepositories != null) {
+			String[] repos = remoteRepositories.split(",");
+			for (String repo : repos) {
+				repoList.add(parseRepository(repo, always));
+			}
+		}
+
+		// Add ImageJ remote repository
+		repoList.add(parseRepository("http://maven.imagej.net/content/groups/public", always));
+
+		/*
+		 * Determine GAV to download
+		 */
+		if (artifactId == null && artifact == null) {
+			throw new MojoFailureException(
+				"No artifact specified (e.g. by -Dartifact=net.imagej:ij:1.48p)");
+		}
+		if (artifact != null) {
+			String[] tokens = artifact.split(":");
+			parseArtifact(tokens);
+		}
+
+		/*
+		 * Install artifact
+		 */
+		try {
+			ProjectBuildingRequest buildingRequest =
+				new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+			buildingRequest.setLocalRepository(localRepository);
+			buildingRequest.setRemoteRepositories(repoList);
+
+			TransformableFilter scopeFilter = ScopeFilter.excluding("system", "provided", "test");
+			TransformableFilter notOptionalFilter = new AbstractFilter() {
+				@Override
+				public boolean accept(Node node, List<Node> parents) {
+					return !node.getDependency().isOptional();
+				}
+			};
+			TransformableFilter scopeAndNotOptionalFilter = new AndFilter(Arrays.asList(scopeFilter, notOptionalFilter));
+
+			Iterable<ArtifactResult> resolveDependencies = dependencyResolver
+				.resolveDependencies(buildingRequest, coordinate, scopeAndNotOptionalFilter);
+			for (ArtifactResult result : resolveDependencies) {
+				try {
+					if ( isSameGAV(coordinate, result.getArtifact()) )
+					{
+						installArtifact( result.getArtifact(), imagejDir, imagejSubdirectory, false, deleteOtherVersionsPolicy );
+						continue;
+					}
+					if (!ignoreDependencies)
+						installArtifact(result.getArtifact(), imagejDir, false,
+							deleteOtherVersionsPolicy);
+				}
+				catch (IOException e) {
+					throw new MojoExecutionException("Couldn't download artifact " +
+						artifact + ": " + e.getMessage(), e);
+				}
+			}
+		}
+		catch (DependencyResolverException e) {
+			throw new MojoExecutionException(
+				"Couldn't resolve dependencies for artifact: " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Checks if a {@link DependableCoordinate} and an {@link Artifact} share
+	 * the same GAV.
+	 *
+	 * @param coordinateToCompare
+	 *            a {@link DependableCoordinate} instance
+	 * @param artifactToCompare
+	 *            an {@link Artifact} instance
+	 * @return true if both parameters share the same GAV; false otherwise
+	 */
+	private boolean isSameGAV(final DependableCoordinate coordinateToCompare, final Artifact artifactToCompare) {
+		boolean same = coordinateToCompare.getGroupId().equals(artifactToCompare.getGroupId());
+		same = same && coordinateToCompare.getArtifactId().equals(artifactToCompare.getArtifactId());
+		same = same && coordinateToCompare.getVersion().equals(artifactToCompare.getVersion());
+		return same;
+	}
+
+	/**
+	 * Parses an artifact string of form
+	 * {@code groupId:artifactId:version[:packaging]}.
+	 * 
+	 * @param tokens
+	 * @throws MojoFailureException
+	 */
+	private void parseArtifact(final String[] tokens) throws MojoFailureException {
+		if (tokens.length != 3) {
+			throw new MojoFailureException(
+				"Invalid artifact, you must specify groupId:artifactId:version " +
+					artifact);
+		}
+		groupId = tokens[0];
+		artifactId = tokens[1];
+		version = tokens[2];
+
+		coordinate.setGroupId(groupId);
+		coordinate.setArtifactId(artifactId);
+		coordinate.setVersion(version);
+
+		if (tokens.length == 4) {
+			coordinate.setType(tokens[3]);
+		}
+	}
+
+	/**
+	 * Parses repository string of form [id::layout::]url
+	 *
+	 * @param repository {@link String} to be parsed
+	 * @param policy The {@link ArtifactRepositoryPolicy} for the repository
+	 * @return an {@link ArtifactRepository} instance
+	 * @throws MojoFailureException
+	 */
+	private ArtifactRepository parseRepository(final String repository,
+		final ArtifactRepositoryPolicy policy) throws MojoFailureException
+	{
+		// if it's a simple url
+		String id = "temp";
+		ArtifactRepositoryLayout layout = getLayout("default");
+		String url = repository;
+
+		// if it's an extended repo URL of the form id::layout::url
+		if (repository.contains("::")) {
+			Matcher matcher = ALT_REPO_SYNTAX_PATTERN.matcher(repository);
+			if (!matcher.matches()) {
+				throw new MojoFailureException(repository,
+					"Invalid syntax for repository: " + repository,
+					"Invalid syntax for repository. Use \"id::layout::url\" or \"URL\".");
+			}
+
+			id = matcher.group(1).trim();
+			if (!StringUtils.isEmpty(matcher.group(2))) {
+				layout = getLayout(matcher.group(2).trim());
+			}
+			url = matcher.group(3).trim();
+		}
+		return new MavenArtifactRepository(id, url, layout, policy, policy);
+	}
+
+	/**
+	 * Determines the layout of a provided repository.
+	 *
+	 * @param id Id to be queried.
+	 * @return An {@link ArtifactRepositoryLayout} instance.
+	 * @throws MojoFailureException
+	 */
+	private ArtifactRepositoryLayout getLayout(final String id)
+		throws MojoFailureException
+	{
+		ArtifactRepositoryLayout layout = repositoryLayouts.get(id);
+
+		if (layout == null) {
+			throw new MojoFailureException(id, "Invalid repository layout",
+				"Invalid repository layout: " + id);
+		}
+
+		return layout;
+	}
+}

--- a/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
@@ -182,10 +182,10 @@ public class InstallArtifactMojo extends AbstractCopyJarsMojo {
 			throw new MojoExecutionException(
 				"The '"+appDirectoryProperty+"' property is unset!");
 		}
-		File imagejDir = new File(appDirectory);
-		if (!imagejDir.isDirectory() && !imagejDir.mkdirs()) {
+		File appDir = new File(appDirectory);
+		if (!appDir.isDirectory() && !appDir.mkdirs()) {
 			throw new MojoFailureException("Could not make directory: " +
-				imagejDir);
+				appDir);
 		}
 
 		if ( appSubdirectory == null )
@@ -252,11 +252,11 @@ public class InstallArtifactMojo extends AbstractCopyJarsMojo {
 				try {
 					if ( isSameGAV(coordinate, result.getArtifact()) )
 					{
-						installArtifact( result.getArtifact(), imagejDir, appSubdirectory, false, deleteOtherVersionsPolicy );
+						installArtifact( result.getArtifact(), appDir, appSubdirectory, false, deleteOtherVersionsPolicy );
 						continue;
 					}
 					if (!ignoreDependencies)
-						installArtifact(result.getArtifact(), imagejDir, false,
+						installArtifact(result.getArtifact(), appDir, false,
 							deleteOtherVersionsPolicy);
 				}
 				catch (IOException e) {

--- a/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
@@ -46,11 +46,8 @@ import org.apache.maven.artifact.repository.ArtifactRepositoryFactory;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -67,10 +64,7 @@ import org.apache.maven.shared.dependencies.DefaultDependableCoordinate;
 import org.apache.maven.shared.dependencies.DependableCoordinate;
 import org.apache.maven.shared.dependencies.resolve.DependencyResolver;
 import org.apache.maven.shared.dependencies.resolve.DependencyResolverException;
-import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.util.StringUtils;
-import org.scijava.maven.plugin.install.AbstractCopyJarsMojo.OtherVersions;
 
 /**
  * Downloads .jar artifacts and their dependencies into a SciJava application
@@ -89,95 +83,6 @@ import org.scijava.maven.plugin.install.AbstractCopyJarsMojo.OtherVersions;
  */
 @Mojo(name = "install-artifact", requiresProject=false)
 public class InstallArtifactMojo extends AbstractCopyJarsMojo {
-
-	/**
-	 * Path to the ImageJ.app/ directory to which artifacts are copied.
-	 * <p>
-	 * If it is not a directory, no .jar files are copied.
-	 * </p>
-	 */
-	@Deprecated
-	@Parameter(property = imagejDirectoryProperty, required = false)
-	private String imagejDirectory;
-
-	/**
-	 * Path to a SciJava application directory (e.g. ImageJ.app) to which
-	 * artifacts are copied.
-	 * <p>
-	 * If it is not a directory, no .jar files are copied.
-	 * </p>
-	 */
-	@Parameter(property = appDirectoryProperty, required = false)
-	private String appDirectory;
-
-	/**
-	 * The name of the property pointing to the subdirectory (beneath e.g.
-	 * {@code jars/} or {@code plugins/}) to which the artifact should be copied.
-	 * <p>
-	 * If no property of that name exists, no subdirectory will be used.
-	 * </p>
-	 */
-	@Deprecated
-	@Parameter(property = imagejSubdirectoryProperty, required = false)
-	private String imagejSubdirectory;
-
-	/**
-	 * The name of the property pointing to the subdirectory (beneath e.g.
-	 * {@code jars/} or {@code plugins/}) to which the artifact should be copied.
-	 * <p>
-	 * If no property of that name exists, no subdirectory will be used.
-	 * </p>
-	 */
-	@Parameter(property = appSubdirectoryProperty, required = false)
-	private String appSubdirectory;
-
-	/**
-	 * Whether to delete other versions when copying the files.
-	 * <p>
-	 * When copying a file and its dependencies to an ImageJ.app/ directory and
-	 * there are other versions of the same file, we can warn or delete those
-	 * other versions.
-	 * </p>
-	 */
-	@Deprecated
-	@Parameter(property = deleteOtherVersionsProperty)
-	private boolean deleteOtherVersions;
-
-	/**
-	 * Whether to delete other versions when copying the files.
-	 * <p>
-	 * When copying a file and its dependencies to an ImageJ.app/ directory and
-	 * there are other versions of the same file, we can warn or delete those
-	 * other versions.
-	 * </p>
-	 */
-	@Deprecated
-	@Parameter(property = imagejDeleteOtherVersionsPolicyProperty)
-	private OtherVersions imagejDeleteOtherVersionsPolicy;
-
-	/**
-	 * Whether to delete other versions when copying the files.
-	 * <p>
-	 * When copying a file and its dependencies to a SciJava application directory
-	 * and there are other versions of the same file, we can warn or delete those
-	 * other versions.
-	 * </p>
-	 */
-	@Parameter(property = deleteOtherVersionsPolicyProperty, defaultValue = "older")
-	private OtherVersions deleteOtherVersionsPolicy;
-
-	/**
-	 * If this option is set to <code>true</code>, only the artifact will be
-	 * copied - without its dependencies.
-	 */
-	@Parameter(property = ignoreDependenciesProperty, defaultValue = "false")
-	private boolean ignoreDependencies;
-
-	/**
-	 * Session
-	 */
-	@Parameter(defaultValue = "${session}")
-	private MavenSession session;
 
 	/**
 	 * Used to look up Artifacts in the remote repository.
@@ -268,13 +173,10 @@ public class InstallArtifactMojo extends AbstractCopyJarsMojo {
 	 */
 	private DefaultDependableCoordinate coordinate = new DefaultDependableCoordinate();
 
-	@Parameter( defaultValue = "${mojoExecution}", readonly = true )
-	MojoExecution mojoExecution;
-
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		// Keep backwards compatibility
-		handleBackwardsCompatibility();
+		// Keep backward compatibility
+		handleBackwardCompatibility();
 
 		if (appDirectory == null) {
 			throw new MojoExecutionException(
@@ -366,64 +268,6 @@ public class InstallArtifactMojo extends AbstractCopyJarsMojo {
 		catch (DependencyResolverException e) {
 			throw new MojoExecutionException(
 				"Couldn't resolve dependencies for artifact: " + e.getMessage(), e);
-		}
-	}
-
-	/**
-	 * TODO Javadoc
-	 */
-	private void handleBackwardsCompatibility() {
-		ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, mojoExecution);
-
-		try {
-			// If at least one scijava.* property is set, ignore imagej.* properties
-			if (evaluator.evaluate("${" + appDirectoryProperty + "}") == null &&
-				evaluator.evaluate("${" + appSubdirectoryProperty + "}") == null &&
-				evaluator.evaluate("${" + deleteOtherVersionsPolicyProperty + "}") == null)
-			{
-
-				// Keep backwards compatibility to delete.other.versions
-				if (evaluator.evaluate("${"+deleteOtherVersionsProperty+"}") != null) {
-					getLog().warn("Property '" + deleteOtherVersionsProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
-					deleteOtherVersionsPolicy = deleteOtherVersions ? OtherVersions.older : OtherVersions.never;
-				}
-
-				// Keep backwards compatibility to imagej.app.directory
-				// Use imagejDirectory if it is set (directly or via imagej.app.directory)
-				if (imagejDirectory != null) {
-					if (evaluator.evaluate("${"+imagejDirectoryProperty+"}") == null) {
-						getLog().warn("Configuration property 'imagejDirectory' is deprecated. Use 'appDirectory' instead");
-					} else {
-						getLog().warn("Property '" + imagejDirectoryProperty + "' is deprecated. Use '"+ appDirectoryProperty +"' instead");
-					}
-					appDirectory = imagejDirectory;
-				}
-
-				// Keep backwards compatibility to imagej.app.subdirectory
-				// Use imagejSubdirectory if it is set (directly or via imagej.app.subdirectory)
-				if (imagejSubdirectory != null) {
-					if (evaluator.evaluate("${"+imagejSubdirectoryProperty+"}") == null) {
-						getLog().warn("Configuration property 'imagejSubdirectory' is deprecated. Use 'appSubdirectory' instead");
-					} else {
-						getLog().warn("Property '" + imagejSubdirectoryProperty + "' is deprecated. Use '"+ appSubdirectoryProperty +"' instead");
-					}
-					appSubdirectory = imagejSubdirectory;
-				}
-
-				// Keep backwards compatibility to imagej.deleteOtherVersions
-				// Use imagejDeleteOtherVersionsPolicy if it is set (directly or via imagej.deleteOtherVersions)
-				if (imagejDeleteOtherVersionsPolicy != null) {
-					if (evaluator.evaluate("${"+imagejDeleteOtherVersionsPolicyProperty+"}") == null) {
-						getLog().warn("Configuration property 'imagejDeleteOtherVersionsPolicy' is deprecated. Use 'deleteOtherVersionsPolicy' instead");
-					} else {
-						getLog().warn("Property '" + imagejDeleteOtherVersionsPolicyProperty + "' is deprecated. Use '"+ deleteOtherVersionsPolicyProperty +"' instead");
-					}
-					deleteOtherVersionsPolicy = imagejDeleteOtherVersionsPolicy;
-				}
-			}
-		}
-		catch (ExpressionEvaluationException e) {
-			getLog().warn(e);
 		}
 	}
 

--- a/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
+++ b/src/main/java/org/scijava/maven/plugin/install/InstallArtifactMojo.java
@@ -72,10 +72,19 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator
 import org.codehaus.plexus.util.StringUtils;
 
 /**
- * Downloads .jar artifacts and their dependencies into an ImageJ.app/ directory
- * structure.
+ * Downloads .jar artifacts and their dependencies into a SciJava application
+ * directory structure.
+ * 
+ * ImageJ 1.x plugins (identified by containing a plugins.config file) get
+ * copied to the plugins/ subdirectory and all other .jar files to jars/.
+ * However, you can override this decision by setting the scijava.app.subdirectory
+ * property to a specific subdirectory. It expects the location of the SciJava
+ * application directory to be specified in the scijava.app.directory property
+ * (which can be set on the Maven command-line). If said property is not set,
+ * the install-artifact goal is skipped.
  * 
  * @author Johannes Schindelin
+ * @author Stefan Helfrich
  */
 @Mojo(name = "install-artifact", requiresProject=false)
 public class InstallArtifactMojo extends AbstractCopyJarsMojo {

--- a/src/main/java/org/scijava/maven/plugin/util/PomEditor.java
+++ b/src/main/java/org/scijava/maven/plugin/util/PomEditor.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/maven/plugin/util/VersionVisitor.java
+++ b/src/main/java/org/scijava/maven/plugin/util/VersionVisitor.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -51,5 +51,15 @@
 				</execute>
 			</action>
 		</pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>copy-jars</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
 	</pluginExecutions>
 </lifecycleMappingMetadata>

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -2,8 +2,9 @@
   #%L
   A plugin for managing SciJava-based projects.
   %%
-  Copyright (C) 2014 - 2016 Board of Regents of the University of
-  Wisconsin-Madison.
+  Copyright (C) 2014 - 2018 Board of Regents of the University of
+  Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+  Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
   %%
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:

--- a/src/test/java/org/scijava/maven/plugin/PomEditorTest.java
+++ b/src/test/java/org/scijava/maven/plugin/PomEditorTest.java
@@ -2,8 +2,9 @@
  * #%L
  * A plugin for managing SciJava-based projects.
  * %%
- * Copyright (C) 2014 - 2016 Board of Regents of the University of
- * Wisconsin-Madison.
+ * Copyright (C) 2014 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, Max Planck
+ * Institute of Molecular Cell Biology and Genetics, and KNIME GmbH.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This PR migrates the functionality of `imagej-maven-plugin` as of [`9240da2`](https://github.com/imagej/imagej-maven-plugin/commit/9240da2782313d829f56cea68e3cd93830a69b3e) to `scijava-maven-plugin`.

It keeps backwards compatibility as far as it's possible. This means, supporting the legacy properties `imagej.app.directory`, `imagej.app.subdirectory`, `imagej.deleteOtherVersions`, and `delete.other.versions`. This means that projects that have used `imagej-maven-plugin` implicitly by making `pom-scijava` the parent for their project, should see no difference once, we switch to `scijava-maven-plugin` in `pom-scijava`.

There is one point that I would like some input on: should the `scijava.*` properties take precedence over `imagej.*` ones if both are set simultaneously? Do you have an opinion, @ctrueden?

TODOs:
- [x] Fix license headers of migrated files
- [x] Rename _imagej*_ to _scijava*_ in `AbstractCopyJarsMojo`