### PR TITLE
Update populate-app test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>28.0.0</version>
+		<version>30.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/it/populate-app/pom.xml
+++ b/src/it/populate-app/pom.xml
@@ -40,13 +40,13 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>ij</artifactId>
-			<version>1.48s</version>
+			<version>1.53g</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/populate-app/verify.bsh
+++ b/src/it/populate-app/verify.bsh
@@ -31,9 +31,9 @@ source(new File(basedir, "../../../src/it/lib.bsh").getPath());
 assertTrue("Should exist: " + plugin, plugin.exists());
 
 // install-artifact must not copy test scope dependencies
-junit = new File(ijDir, "../Other.app/jars/junit-4.8.1.jar");
+junit = new File(ijDir, "../Other.app/jars/junit-4.13.2.jar");
 assertTrue("Should not exist: " + junit, !junit.exists());
 
 // but it must copy the ij dependency
-ij = new File(ijDir, "../Other.app/jars/ij-1.48s.jar");
+ij = new File(ijDir, "../Other.app/jars/ij-1.53g.jar");
 assertTrue("ImageJ 1.x was not copied: " + ij, ij.exists());


### PR DESCRIPTION
This PR updates dependency versions in the populate-app test to avoid a Dependabot alert about security vulnerabilities, related to an obsolete `junit` version being used in this test.

It also bumps the parent `pom-scijava` version to `30.0.0`.