### PR TITLE
Add switch to ignore optional dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 			<url>https://imagej.net/User:Hinerm</url>
 			<properties><id>hinerm</id></properties>
 		</contributor>
+		<contributor>
+			<name>Philipp Hanslovsky</name>
+			<url>https://github.com/hanslovsky</url>
+			<properties><id>hanslovsky</id></properties>
+		</contributor>
 	</contributors>
 
 	<mailingLists>


### PR DESCRIPTION
In current master branch, the `InstallArtifactMojo` ignores dependencies marked as `optional`, while the `PopulateAppMojo` does not. When creating shaded and deploying into `Fiji.app`, it is necessary to be able to ignore optional dependencies because `provided` dependencies are ignored both by the `PopulateAppMojo` and the shade plugin (not just by the `PopulateAppMojo`), e.g. scijava/scripting-kotlin#6. This PR adds the property `scijava.ignoreOptionalDependencies` to control this behavior both in the `InstallArtifactMojo` and the `PopulateAppMojo`. I decided against simply changing `PopulateAppMojo` to hard-code ignoring optional dependencies (as is done in `InstallArtifactMojo`) because it may break some existing builds. For the same reason, `PopulateAppMojo` and `InstallArtifactMojo` have different default values for `scijava.ignoreOptionalDependencies`.